### PR TITLE
DSE-55126: ProfileIds of HF models should not be modified

### DIFF
--- a/models/airgapped/csk/1.57.0_concatenated.yaml
+++ b/models/airgapped/csk/1.57.0_concatenated.yaml
@@ -19335,7 +19335,7 @@ models:
         - label: Use Policy
           url: https://ai.google.dev/gemma/prohibited_use_policy
       optimizationProfiles:
-        - profileId: google/gemma-2-9b-a10g
+        - profileId: google/gemma-2-9b
           displayName: Gemma 2 9b A10G
           framework: vllm
           sha: vllm
@@ -19345,7 +19345,7 @@ models:
               value: A10G
             - key: COUNT
               value: 1
-        - profileId: google/gemma-2-9b-a100
+        - profileId: google/gemma-2-9b
           displayName: Gemma 2 A100
           framework: vllm
           sha: vllm
@@ -19355,7 +19355,7 @@ models:
               value: A100
             - key: COUNT
               value: 1
-        - profileId: google/gemma-2-9b-l40s
+        - profileId: google/gemma-2-9b
           displayName: Gemma 2 9b L40S
           framework: vllm
           sha: vllm
@@ -19392,7 +19392,7 @@ models:
         - label: License Agreement
           url: https://choosealicense.com/licenses/cc-by-sa-4.0/
       optimizationProfiles:
-        - profileId: defog/llama-3-sqlcoder-8b-a10g
+        - profileId: defog/llama-3-sqlcoder-8b
           displayName: Llama 3 SQLCoder 8B A10G
           framework: vllm
           sha: vllm
@@ -19402,7 +19402,7 @@ models:
               value: A10G
             - key: COUNT
               value: 1
-        - profileId: defog/llama-3-sqlcoder-8b-a100
+        - profileId: defog/llama-3-sqlcoder-8b
           displayName: Llama 3 SQLCoder 8B A100
           framework: vllm
           sha: vllm
@@ -19412,7 +19412,7 @@ models:
               value: A100
             - key: COUNT
               value: 1
-        - profileId: defog/llama-3-sqlcoder-8b-l40s
+        - profileId: defog/llama-3-sqlcoder-8b
           displayName: Llama 3 SQLCoder 8B L40S
           framework: vllm
           sha: vllm

--- a/models/airgapped/csk/1.58.0_concatenated.yaml
+++ b/models/airgapped/csk/1.58.0_concatenated.yaml
@@ -19335,7 +19335,7 @@ models:
         - label: Use Policy
           url: https://ai.google.dev/gemma/prohibited_use_policy
       optimizationProfiles:
-        - profileId: google/gemma-2-9b-a10g
+        - profileId: google/gemma-2-9b
           displayName: Gemma 2 9b A10G
           framework: vllm
           sha: vllm
@@ -19345,7 +19345,7 @@ models:
               value: A10G
             - key: COUNT
               value: 1
-        - profileId: google/gemma-2-9b-a100
+        - profileId: google/gemma-2-9b
           displayName: Gemma 2 A100
           framework: vllm
           sha: vllm
@@ -19355,7 +19355,7 @@ models:
               value: A100
             - key: COUNT
               value: 1
-        - profileId: google/gemma-2-9b-l40s
+        - profileId: google/gemma-2-9b
           displayName: Gemma 2 9b L40S
           framework: vllm
           sha: vllm
@@ -19392,7 +19392,7 @@ models:
         - label: License Agreement
           url: https://choosealicense.com/licenses/cc-by-sa-4.0/
       optimizationProfiles:
-        - profileId: defog/llama-3-sqlcoder-8b-a10g
+        - profileId: defog/llama-3-sqlcoder-8b
           displayName: Llama 3 SQLCoder 8B A10G
           framework: vllm
           sha: vllm
@@ -19402,7 +19402,7 @@ models:
               value: A10G
             - key: COUNT
               value: 1
-        - profileId: defog/llama-3-sqlcoder-8b-a100
+        - profileId: defog/llama-3-sqlcoder-8b
           displayName: Llama 3 SQLCoder 8B A100
           framework: vllm
           sha: vllm
@@ -19412,7 +19412,7 @@ models:
               value: A100
             - key: COUNT
               value: 1
-        - profileId: defog/llama-3-sqlcoder-8b-l40s
+        - profileId: defog/llama-3-sqlcoder-8b
           displayName: Llama 3 SQLCoder 8B L40S
           framework: vllm
           sha: vllm

--- a/models/airgapped/private/1.56.0-h3000_concatenated.yaml
+++ b/models/airgapped/private/1.56.0-h3000_concatenated.yaml
@@ -19335,7 +19335,7 @@ models:
         - label: Use Policy
           url: https://ai.google.dev/gemma/prohibited_use_policy
       optimizationProfiles:
-        - profileId: google/gemma-2-9b-a10g
+        - profileId: google/gemma-2-9b
           displayName: Gemma 2 9b A10G
           framework: vllm
           sha: vllm
@@ -19345,7 +19345,7 @@ models:
               value: A10G
             - key: COUNT
               value: 1
-        - profileId: google/gemma-2-9b-a100
+        - profileId: google/gemma-2-9b
           displayName: Gemma 2 A100
           framework: vllm
           sha: vllm
@@ -19355,7 +19355,7 @@ models:
               value: A100
             - key: COUNT
               value: 1
-        - profileId: google/gemma-2-9b-l40s
+        - profileId: google/gemma-2-9b
           displayName: Gemma 2 9b L40S
           framework: vllm
           sha: vllm
@@ -19392,7 +19392,7 @@ models:
         - label: License Agreement
           url: https://choosealicense.com/licenses/cc-by-sa-4.0/
       optimizationProfiles:
-        - profileId: defog/llama-3-sqlcoder-8b-a10g
+        - profileId: defog/llama-3-sqlcoder-8b
           displayName: Llama 3 SQLCoder 8B A10G
           framework: vllm
           sha: vllm
@@ -19402,7 +19402,7 @@ models:
               value: A10G
             - key: COUNT
               value: 1
-        - profileId: defog/llama-3-sqlcoder-8b-a100
+        - profileId: defog/llama-3-sqlcoder-8b
           displayName: Llama 3 SQLCoder 8B A100
           framework: vllm
           sha: vllm
@@ -19412,7 +19412,7 @@ models:
               value: A100
             - key: COUNT
               value: 1
-        - profileId: defog/llama-3-sqlcoder-8b-l40s
+        - profileId: defog/llama-3-sqlcoder-8b
           displayName: Llama 3 SQLCoder 8B L40S
           framework: vllm
           sha: vllm

--- a/models/airgapped/private/1.56.0_concatenated.yaml
+++ b/models/airgapped/private/1.56.0_concatenated.yaml
@@ -19335,7 +19335,7 @@ models:
         - label: Use Policy
           url: https://ai.google.dev/gemma/prohibited_use_policy
       optimizationProfiles:
-        - profileId: google/gemma-2-9b-a10g
+        - profileId: google/gemma-2-9b
           displayName: Gemma 2 9b A10G
           framework: vllm
           sha: vllm
@@ -19345,7 +19345,7 @@ models:
               value: A10G
             - key: COUNT
               value: 1
-        - profileId: google/gemma-2-9b-a100
+        - profileId: google/gemma-2-9b
           displayName: Gemma 2 A100
           framework: vllm
           sha: vllm
@@ -19355,7 +19355,7 @@ models:
               value: A100
             - key: COUNT
               value: 1
-        - profileId: google/gemma-2-9b-l40s
+        - profileId: google/gemma-2-9b
           displayName: Gemma 2 9b L40S
           framework: vllm
           sha: vllm
@@ -19392,7 +19392,7 @@ models:
         - label: License Agreement
           url: https://choosealicense.com/licenses/cc-by-sa-4.0/
       optimizationProfiles:
-        - profileId: defog/llama-3-sqlcoder-8b-a10g
+        - profileId: defog/llama-3-sqlcoder-8b
           displayName: Llama 3 SQLCoder 8B A10G
           framework: vllm
           sha: vllm
@@ -19402,7 +19402,7 @@ models:
               value: A10G
             - key: COUNT
               value: 1
-        - profileId: defog/llama-3-sqlcoder-8b-a100
+        - profileId: defog/llama-3-sqlcoder-8b
           displayName: Llama 3 SQLCoder 8B A100
           framework: vllm
           sha: vllm
@@ -19412,7 +19412,7 @@ models:
               value: A100
             - key: COUNT
               value: 1
-        - profileId: defog/llama-3-sqlcoder-8b-l40s
+        - profileId: defog/llama-3-sqlcoder-8b
           displayName: Llama 3 SQLCoder 8B L40S
           framework: vllm
           sha: vllm

--- a/models/airgapped/private/1.58.0_concatenated.yaml
+++ b/models/airgapped/private/1.58.0_concatenated.yaml
@@ -19335,7 +19335,7 @@ models:
         - label: Use Policy
           url: https://ai.google.dev/gemma/prohibited_use_policy
       optimizationProfiles:
-        - profileId: google/gemma-2-9b-a10g
+        - profileId: google/gemma-2-9b
           displayName: Gemma 2 9b A10G
           framework: vllm
           sha: vllm
@@ -19345,7 +19345,7 @@ models:
               value: A10G
             - key: COUNT
               value: 1
-        - profileId: google/gemma-2-9b-a100
+        - profileId: google/gemma-2-9b
           displayName: Gemma 2 A100
           framework: vllm
           sha: vllm
@@ -19355,7 +19355,7 @@ models:
               value: A100
             - key: COUNT
               value: 1
-        - profileId: google/gemma-2-9b-l40s
+        - profileId: google/gemma-2-9b
           displayName: Gemma 2 9b L40S
           framework: vllm
           sha: vllm
@@ -19392,7 +19392,7 @@ models:
         - label: License Agreement
           url: https://choosealicense.com/licenses/cc-by-sa-4.0/
       optimizationProfiles:
-        - profileId: defog/llama-3-sqlcoder-8b-a10g
+        - profileId: defog/llama-3-sqlcoder-8b
           displayName: Llama 3 SQLCoder 8B A10G
           framework: vllm
           sha: vllm
@@ -19402,7 +19402,7 @@ models:
               value: A10G
             - key: COUNT
               value: 1
-        - profileId: defog/llama-3-sqlcoder-8b-a100
+        - profileId: defog/llama-3-sqlcoder-8b
           displayName: Llama 3 SQLCoder 8B A100
           framework: vllm
           sha: vllm
@@ -19412,7 +19412,7 @@ models:
               value: A100
             - key: COUNT
               value: 1
-        - profileId: defog/llama-3-sqlcoder-8b-l40s
+        - profileId: defog/llama-3-sqlcoder-8b
           displayName: Llama 3 SQLCoder 8B L40S
           framework: vllm
           sha: vllm

--- a/models/airgapped/public/1.55.0-h1000_concatenated.yaml
+++ b/models/airgapped/public/1.55.0-h1000_concatenated.yaml
@@ -11582,7 +11582,7 @@ models:
         - label: Use Policy
           url: https://ai.google.dev/gemma/prohibited_use_policy
       optimizationProfiles:
-        - profileId: google/gemma-2-9b-a10g
+        - profileId: google/gemma-2-9b
           displayName: Gemma 2 9b A10G
           framework: vllm
           sha: vllm
@@ -11595,7 +11595,7 @@ models:
               value: A10G
             - key: COUNT
               value: 1
-        - profileId: google/gemma-2-9b-a100
+        - profileId: google/gemma-2-9b
           displayName: Gemma 2 A100
           framework: vllm
           sha: vllm
@@ -11608,7 +11608,7 @@ models:
               value: A100
             - key: COUNT
               value: 1
-        - profileId: google/gemma-2-9b-l40s
+        - profileId: google/gemma-2-9b
           displayName: Gemma 2 9b L40S
           framework: vllm
           sha: vllm
@@ -11648,7 +11648,7 @@ models:
         - label: License Agreement
           url: https://choosealicense.com/licenses/cc-by-sa-4.0/
       optimizationProfiles:
-        - profileId: defog/llama-3-sqlcoder-8b-a10g
+        - profileId: defog/llama-3-sqlcoder-8b
           displayName: Llama 3 SQLCoder 8B A10G
           framework: vllm
           sha: vllm
@@ -11658,7 +11658,7 @@ models:
               value: A10G
             - key: COUNT
               value: 1
-        - profileId: defog/llama-3-sqlcoder-8b-a100
+        - profileId: defog/llama-3-sqlcoder-8b
           displayName: Llama 3 SQLCoder 8B A100
           framework: vllm
           sha: vllm
@@ -11668,7 +11668,7 @@ models:
               value: A100
             - key: COUNT
               value: 1
-        - profileId: defog/llama-3-sqlcoder-8b-l40s
+        - profileId: defog/llama-3-sqlcoder-8b
           displayName: Llama 3 SQLCoder 8B L40S
           framework: vllm
           sha: vllm

--- a/models/airgapped/public/1.58.0_concatenated.yaml
+++ b/models/airgapped/public/1.58.0_concatenated.yaml
@@ -11582,7 +11582,7 @@ models:
         - label: Use Policy
           url: https://ai.google.dev/gemma/prohibited_use_policy
       optimizationProfiles:
-        - profileId: google/gemma-2-9b-a10g
+        - profileId: google/gemma-2-9b
           displayName: Gemma 2 9b A10G
           framework: vllm
           sha: vllm
@@ -11595,7 +11595,7 @@ models:
               value: A10G
             - key: COUNT
               value: 1
-        - profileId: google/gemma-2-9b-a100
+        - profileId: google/gemma-2-9b
           displayName: Gemma 2 A100
           framework: vllm
           sha: vllm
@@ -11608,7 +11608,7 @@ models:
               value: A100
             - key: COUNT
               value: 1
-        - profileId: google/gemma-2-9b-l40s
+        - profileId: google/gemma-2-9b
           displayName: Gemma 2 9b L40S
           framework: vllm
           sha: vllm
@@ -11648,7 +11648,7 @@ models:
         - label: License Agreement
           url: https://choosealicense.com/licenses/cc-by-sa-4.0/
       optimizationProfiles:
-        - profileId: defog/llama-3-sqlcoder-8b-a10g
+        - profileId: defog/llama-3-sqlcoder-8b
           displayName: Llama 3 SQLCoder 8B A10G
           framework: vllm
           sha: vllm
@@ -11658,7 +11658,7 @@ models:
               value: A10G
             - key: COUNT
               value: 1
-        - profileId: defog/llama-3-sqlcoder-8b-a100
+        - profileId: defog/llama-3-sqlcoder-8b
           displayName: Llama 3 SQLCoder 8B A100
           framework: vllm
           sha: vllm
@@ -11668,7 +11668,7 @@ models:
               value: A100
             - key: COUNT
               value: 1
-        - profileId: defog/llama-3-sqlcoder-8b-l40s
+        - profileId: defog/llama-3-sqlcoder-8b
           displayName: Llama 3 SQLCoder 8B L40S
           framework: vllm
           sha: vllm

--- a/models/csk/1.57.0/gemma-2.yaml
+++ b/models/csk/1.57.0/gemma-2.yaml
@@ -18,7 +18,7 @@ models:
     - label: Use Policy
       url: https://ai.google.dev/gemma/prohibited_use_policy
     optimizationProfiles:
-    - profileId: google/gemma-2-9b-a10g
+    - profileId: google/gemma-2-9b
       displayName: Gemma 2 9b A10G
       framework: vllm
       sha: vllm
@@ -28,7 +28,7 @@ models:
         value: A10G
       - key: COUNT
         value: 1
-    - profileId: google/gemma-2-9b-a100
+    - profileId: google/gemma-2-9b
       displayName: Gemma 2 A100
       framework: vllm
       sha: vllm
@@ -38,7 +38,7 @@ models:
         value: A100
       - key: COUNT
         value: 1
-    - profileId: google/gemma-2-9b-l40s
+    - profileId: google/gemma-2-9b
       displayName: Gemma 2 9b L40S
       framework: vllm
       sha: vllm

--- a/models/csk/1.57.0/llama-3-sqlcoder-8b.yaml
+++ b/models/csk/1.57.0/llama-3-sqlcoder-8b.yaml
@@ -17,7 +17,7 @@ models:
     - label: License Agreement
       url: https://choosealicense.com/licenses/cc-by-sa-4.0/
     optimizationProfiles:
-    - profileId: defog/llama-3-sqlcoder-8b-a10g
+    - profileId: defog/llama-3-sqlcoder-8b
       displayName: Llama 3 SQLCoder 8B A10G
       framework: vllm
       sha: vllm
@@ -27,7 +27,7 @@ models:
         value: A10G
       - key: COUNT
         value: 1
-    - profileId: defog/llama-3-sqlcoder-8b-a100
+    - profileId: defog/llama-3-sqlcoder-8b
       displayName: Llama 3 SQLCoder 8B A100
       framework: vllm
       sha: vllm
@@ -37,7 +37,7 @@ models:
         value: A100
       - key: COUNT
         value: 1
-    - profileId: defog/llama-3-sqlcoder-8b-l40s
+    - profileId: defog/llama-3-sqlcoder-8b
       displayName: Llama 3 SQLCoder 8B L40S
       framework: vllm
       sha: vllm

--- a/models/csk/1.58.0/gemma-2.yaml
+++ b/models/csk/1.58.0/gemma-2.yaml
@@ -18,7 +18,7 @@ models:
     - label: Use Policy
       url: https://ai.google.dev/gemma/prohibited_use_policy
     optimizationProfiles:
-    - profileId: google/gemma-2-9b-a10g
+    - profileId: google/gemma-2-9b
       displayName: Gemma 2 9b A10G
       framework: vllm
       sha: vllm
@@ -28,7 +28,7 @@ models:
         value: A10G
       - key: COUNT
         value: 1
-    - profileId: google/gemma-2-9b-a100
+    - profileId: google/gemma-2-9b
       displayName: Gemma 2 A100
       framework: vllm
       sha: vllm
@@ -38,7 +38,7 @@ models:
         value: A100
       - key: COUNT
         value: 1
-    - profileId: google/gemma-2-9b-l40s
+    - profileId: google/gemma-2-9b
       displayName: Gemma 2 9b L40S
       framework: vllm
       sha: vllm

--- a/models/csk/1.58.0/llama-3-sqlcoder-8b.yaml
+++ b/models/csk/1.58.0/llama-3-sqlcoder-8b.yaml
@@ -17,7 +17,7 @@ models:
     - label: License Agreement
       url: https://choosealicense.com/licenses/cc-by-sa-4.0/
     optimizationProfiles:
-    - profileId: defog/llama-3-sqlcoder-8b-a10g
+    - profileId: defog/llama-3-sqlcoder-8b
       displayName: Llama 3 SQLCoder 8B A10G
       framework: vllm
       sha: vllm
@@ -27,7 +27,7 @@ models:
         value: A10G
       - key: COUNT
         value: 1
-    - profileId: defog/llama-3-sqlcoder-8b-a100
+    - profileId: defog/llama-3-sqlcoder-8b
       displayName: Llama 3 SQLCoder 8B A100
       framework: vllm
       sha: vllm
@@ -37,7 +37,7 @@ models:
         value: A100
       - key: COUNT
         value: 1
-    - profileId: defog/llama-3-sqlcoder-8b-l40s
+    - profileId: defog/llama-3-sqlcoder-8b
       displayName: Llama 3 SQLCoder 8B L40S
       framework: vllm
       sha: vllm

--- a/models/csk/gemma-2.yaml
+++ b/models/csk/gemma-2.yaml
@@ -18,7 +18,7 @@ models:
     - label: Use Policy
       url: https://ai.google.dev/gemma/prohibited_use_policy
     optimizationProfiles:
-    - profileId: google/gemma-2-9b-a10g
+    - profileId: google/gemma-2-9b
       displayName: Gemma 2 9b A10G
       framework: vllm
       sha: vllm
@@ -28,7 +28,7 @@ models:
         value: A10G
       - key: COUNT
         value: 1
-    - profileId: google/gemma-2-9b-a100
+    - profileId: google/gemma-2-9b
       displayName: Gemma 2 A100
       framework: vllm
       sha: vllm
@@ -38,7 +38,7 @@ models:
         value: A100
       - key: COUNT
         value: 1
-    - profileId: google/gemma-2-9b-l40s
+    - profileId: google/gemma-2-9b
       displayName: Gemma 2 9b L40S
       framework: vllm
       sha: vllm

--- a/models/csk/llama-3-sqlcoder-8b.yaml
+++ b/models/csk/llama-3-sqlcoder-8b.yaml
@@ -17,7 +17,7 @@ models:
     - label: License Agreement
       url: https://choosealicense.com/licenses/cc-by-sa-4.0/
     optimizationProfiles:
-    - profileId: defog/llama-3-sqlcoder-8b-a10g
+    - profileId: defog/llama-3-sqlcoder-8b
       displayName: Llama 3 SQLCoder 8B A10G
       framework: vllm
       sha: vllm
@@ -27,7 +27,7 @@ models:
         value: A10G
       - key: COUNT
         value: 1
-    - profileId: defog/llama-3-sqlcoder-8b-a100
+    - profileId: defog/llama-3-sqlcoder-8b
       displayName: Llama 3 SQLCoder 8B A100
       framework: vllm
       sha: vllm
@@ -37,7 +37,7 @@ models:
         value: A100
       - key: COUNT
         value: 1
-    - profileId: defog/llama-3-sqlcoder-8b-l40s
+    - profileId: defog/llama-3-sqlcoder-8b
       displayName: Llama 3 SQLCoder 8B L40S
       framework: vllm
       sha: vllm

--- a/models/private/1.56.0-h3000/gemma-2.yaml
+++ b/models/private/1.56.0-h3000/gemma-2.yaml
@@ -18,7 +18,7 @@ models:
     - label: Use Policy
       url: https://ai.google.dev/gemma/prohibited_use_policy
     optimizationProfiles:
-    - profileId: google/gemma-2-9b-a10g
+    - profileId: google/gemma-2-9b
       displayName: Gemma 2 9b A10G
       framework: vllm
       sha: vllm
@@ -28,7 +28,7 @@ models:
         value: A10G
       - key: COUNT
         value: 1
-    - profileId: google/gemma-2-9b-a100
+    - profileId: google/gemma-2-9b
       displayName: Gemma 2 A100
       framework: vllm
       sha: vllm
@@ -38,7 +38,7 @@ models:
         value: A100
       - key: COUNT
         value: 1
-    - profileId: google/gemma-2-9b-l40s
+    - profileId: google/gemma-2-9b
       displayName: Gemma 2 9b L40S
       framework: vllm
       sha: vllm

--- a/models/private/1.56.0-h3000/llama-3-sqlcoder-8b.yaml
+++ b/models/private/1.56.0-h3000/llama-3-sqlcoder-8b.yaml
@@ -17,7 +17,7 @@ models:
     - label: License Agreement
       url: https://choosealicense.com/licenses/cc-by-sa-4.0/
     optimizationProfiles:
-    - profileId: defog/llama-3-sqlcoder-8b-a10g
+    - profileId: defog/llama-3-sqlcoder-8b
       displayName: Llama 3 SQLCoder 8B A10G
       framework: vllm
       sha: vllm
@@ -27,7 +27,7 @@ models:
         value: A10G
       - key: COUNT
         value: 1
-    - profileId: defog/llama-3-sqlcoder-8b-a100
+    - profileId: defog/llama-3-sqlcoder-8b
       displayName: Llama 3 SQLCoder 8B A100
       framework: vllm
       sha: vllm
@@ -37,7 +37,7 @@ models:
         value: A100
       - key: COUNT
         value: 1
-    - profileId: defog/llama-3-sqlcoder-8b-l40s
+    - profileId: defog/llama-3-sqlcoder-8b
       displayName: Llama 3 SQLCoder 8B L40S
       framework: vllm
       sha: vllm

--- a/models/private/1.56.0/gemma-2.yaml
+++ b/models/private/1.56.0/gemma-2.yaml
@@ -18,7 +18,7 @@ models:
     - label: Use Policy
       url: https://ai.google.dev/gemma/prohibited_use_policy
     optimizationProfiles:
-    - profileId: google/gemma-2-9b-a10g
+    - profileId: google/gemma-2-9b
       displayName: Gemma 2 9b A10G
       framework: vllm
       sha: vllm
@@ -28,7 +28,7 @@ models:
         value: A10G
       - key: COUNT
         value: 1
-    - profileId: google/gemma-2-9b-a100
+    - profileId: google/gemma-2-9b
       displayName: Gemma 2 A100
       framework: vllm
       sha: vllm
@@ -38,7 +38,7 @@ models:
         value: A100
       - key: COUNT
         value: 1
-    - profileId: google/gemma-2-9b-l40s
+    - profileId: google/gemma-2-9b
       displayName: Gemma 2 9b L40S
       framework: vllm
       sha: vllm

--- a/models/private/1.56.0/llama-3-sqlcoder-8b.yaml
+++ b/models/private/1.56.0/llama-3-sqlcoder-8b.yaml
@@ -17,7 +17,7 @@ models:
     - label: License Agreement
       url: https://choosealicense.com/licenses/cc-by-sa-4.0/
     optimizationProfiles:
-    - profileId: defog/llama-3-sqlcoder-8b-a10g
+    - profileId: defog/llama-3-sqlcoder-8b
       displayName: Llama 3 SQLCoder 8B A10G
       framework: vllm
       sha: vllm
@@ -27,7 +27,7 @@ models:
         value: A10G
       - key: COUNT
         value: 1
-    - profileId: defog/llama-3-sqlcoder-8b-a100
+    - profileId: defog/llama-3-sqlcoder-8b
       displayName: Llama 3 SQLCoder 8B A100
       framework: vllm
       sha: vllm
@@ -37,7 +37,7 @@ models:
         value: A100
       - key: COUNT
         value: 1
-    - profileId: defog/llama-3-sqlcoder-8b-l40s
+    - profileId: defog/llama-3-sqlcoder-8b
       displayName: Llama 3 SQLCoder 8B L40S
       framework: vllm
       sha: vllm

--- a/models/private/1.58.0/gemma-2.yaml
+++ b/models/private/1.58.0/gemma-2.yaml
@@ -18,7 +18,7 @@ models:
     - label: Use Policy
       url: https://ai.google.dev/gemma/prohibited_use_policy
     optimizationProfiles:
-    - profileId: google/gemma-2-9b-a10g
+    - profileId: google/gemma-2-9b
       displayName: Gemma 2 9b A10G
       framework: vllm
       sha: vllm
@@ -28,7 +28,7 @@ models:
         value: A10G
       - key: COUNT
         value: 1
-    - profileId: google/gemma-2-9b-a100
+    - profileId: google/gemma-2-9b
       displayName: Gemma 2 A100
       framework: vllm
       sha: vllm
@@ -38,7 +38,7 @@ models:
         value: A100
       - key: COUNT
         value: 1
-    - profileId: google/gemma-2-9b-l40s
+    - profileId: google/gemma-2-9b
       displayName: Gemma 2 9b L40S
       framework: vllm
       sha: vllm

--- a/models/private/1.58.0/llama-3-sqlcoder-8b.yaml
+++ b/models/private/1.58.0/llama-3-sqlcoder-8b.yaml
@@ -17,7 +17,7 @@ models:
     - label: License Agreement
       url: https://choosealicense.com/licenses/cc-by-sa-4.0/
     optimizationProfiles:
-    - profileId: defog/llama-3-sqlcoder-8b-a10g
+    - profileId: defog/llama-3-sqlcoder-8b
       displayName: Llama 3 SQLCoder 8B A10G
       framework: vllm
       sha: vllm
@@ -27,7 +27,7 @@ models:
         value: A10G
       - key: COUNT
         value: 1
-    - profileId: defog/llama-3-sqlcoder-8b-a100
+    - profileId: defog/llama-3-sqlcoder-8b
       displayName: Llama 3 SQLCoder 8B A100
       framework: vllm
       sha: vllm
@@ -37,7 +37,7 @@ models:
         value: A100
       - key: COUNT
         value: 1
-    - profileId: defog/llama-3-sqlcoder-8b-l40s
+    - profileId: defog/llama-3-sqlcoder-8b
       displayName: Llama 3 SQLCoder 8B L40S
       framework: vllm
       sha: vllm

--- a/models/private/gemma-2.yaml
+++ b/models/private/gemma-2.yaml
@@ -18,7 +18,7 @@ models:
     - label: Use Policy
       url: https://ai.google.dev/gemma/prohibited_use_policy
     optimizationProfiles:
-    - profileId: google/gemma-2-9b-a10g
+    - profileId: google/gemma-2-9b
       displayName: Gemma 2 9b A10G
       framework: vllm
       sha: vllm
@@ -28,7 +28,7 @@ models:
         value: A10G
       - key: COUNT
         value: 1
-    - profileId: google/gemma-2-9b-a100
+    - profileId: google/gemma-2-9b
       displayName: Gemma 2 A100
       framework: vllm
       sha: vllm
@@ -38,7 +38,7 @@ models:
         value: A100
       - key: COUNT
         value: 1
-    - profileId: google/gemma-2-9b-l40s
+    - profileId: google/gemma-2-9b
       displayName: Gemma 2 9b L40S
       framework: vllm
       sha: vllm

--- a/models/private/llama-3-sqlcoder-8b.yaml
+++ b/models/private/llama-3-sqlcoder-8b.yaml
@@ -17,7 +17,7 @@ models:
     - label: License Agreement
       url: https://choosealicense.com/licenses/cc-by-sa-4.0/
     optimizationProfiles:
-    - profileId: defog/llama-3-sqlcoder-8b-a10g
+    - profileId: defog/llama-3-sqlcoder-8b
       displayName: Llama 3 SQLCoder 8B A10G
       framework: vllm
       sha: vllm
@@ -27,7 +27,7 @@ models:
         value: A10G
       - key: COUNT
         value: 1
-    - profileId: defog/llama-3-sqlcoder-8b-a100
+    - profileId: defog/llama-3-sqlcoder-8b
       displayName: Llama 3 SQLCoder 8B A100
       framework: vllm
       sha: vllm
@@ -37,7 +37,7 @@ models:
         value: A100
       - key: COUNT
         value: 1
-    - profileId: defog/llama-3-sqlcoder-8b-l40s
+    - profileId: defog/llama-3-sqlcoder-8b
       displayName: Llama 3 SQLCoder 8B L40S
       framework: vllm
       sha: vllm

--- a/models/public/1.55.0-h1000/gemma-2.yaml
+++ b/models/public/1.55.0-h1000/gemma-2.yaml
@@ -18,7 +18,7 @@ models:
     - label: Use Policy
       url: https://ai.google.dev/gemma/prohibited_use_policy
     optimizationProfiles:
-    - profileId: google/gemma-2-9b-a10g
+    - profileId: google/gemma-2-9b
       displayName: Gemma 2 9b A10G
       framework: vllm
       sha: vllm
@@ -31,7 +31,7 @@ models:
         value: A10G
       - key: COUNT
         value: 1
-    - profileId: google/gemma-2-9b-a100
+    - profileId: google/gemma-2-9b
       displayName: Gemma 2 A100
       framework: vllm
       sha: vllm
@@ -44,7 +44,7 @@ models:
         value: A100
       - key: COUNT
         value: 1
-    - profileId: google/gemma-2-9b-l40s
+    - profileId: google/gemma-2-9b
       displayName: Gemma 2 9b L40S
       framework: vllm
       sha: vllm

--- a/models/public/1.55.0-h1000/llama-3-sqlcoder-8b.yaml
+++ b/models/public/1.55.0-h1000/llama-3-sqlcoder-8b.yaml
@@ -17,7 +17,7 @@ models:
     - label: License Agreement
       url: https://choosealicense.com/licenses/cc-by-sa-4.0/
     optimizationProfiles:
-    - profileId: defog/llama-3-sqlcoder-8b-a10g
+    - profileId: defog/llama-3-sqlcoder-8b
       displayName: Llama 3 SQLCoder 8B A10G
       framework: vllm
       sha: vllm
@@ -27,7 +27,7 @@ models:
         value: A10G
       - key: COUNT
         value: 1
-    - profileId: defog/llama-3-sqlcoder-8b-a100
+    - profileId: defog/llama-3-sqlcoder-8b
       displayName: Llama 3 SQLCoder 8B A100
       framework: vllm
       sha: vllm
@@ -37,7 +37,7 @@ models:
         value: A100
       - key: COUNT
         value: 1
-    - profileId: defog/llama-3-sqlcoder-8b-l40s
+    - profileId: defog/llama-3-sqlcoder-8b
       displayName: Llama 3 SQLCoder 8B L40S
       framework: vllm
       sha: vllm

--- a/models/public/1.58.0/gemma-2.yaml
+++ b/models/public/1.58.0/gemma-2.yaml
@@ -18,7 +18,7 @@ models:
     - label: Use Policy
       url: https://ai.google.dev/gemma/prohibited_use_policy
     optimizationProfiles:
-    - profileId: google/gemma-2-9b-a10g
+    - profileId: google/gemma-2-9b
       displayName: Gemma 2 9b A10G
       framework: vllm
       sha: vllm
@@ -31,7 +31,7 @@ models:
         value: A10G
       - key: COUNT
         value: 1
-    - profileId: google/gemma-2-9b-a100
+    - profileId: google/gemma-2-9b
       displayName: Gemma 2 A100
       framework: vllm
       sha: vllm
@@ -44,7 +44,7 @@ models:
         value: A100
       - key: COUNT
         value: 1
-    - profileId: google/gemma-2-9b-l40s
+    - profileId: google/gemma-2-9b
       displayName: Gemma 2 9b L40S
       framework: vllm
       sha: vllm

--- a/models/public/1.58.0/llama-3-sqlcoder-8b.yaml
+++ b/models/public/1.58.0/llama-3-sqlcoder-8b.yaml
@@ -17,7 +17,7 @@ models:
     - label: License Agreement
       url: https://choosealicense.com/licenses/cc-by-sa-4.0/
     optimizationProfiles:
-    - profileId: defog/llama-3-sqlcoder-8b-a10g
+    - profileId: defog/llama-3-sqlcoder-8b
       displayName: Llama 3 SQLCoder 8B A10G
       framework: vllm
       sha: vllm
@@ -27,7 +27,7 @@ models:
         value: A10G
       - key: COUNT
         value: 1
-    - profileId: defog/llama-3-sqlcoder-8b-a100
+    - profileId: defog/llama-3-sqlcoder-8b
       displayName: Llama 3 SQLCoder 8B A100
       framework: vllm
       sha: vllm
@@ -37,7 +37,7 @@ models:
         value: A100
       - key: COUNT
         value: 1
-    - profileId: defog/llama-3-sqlcoder-8b-l40s
+    - profileId: defog/llama-3-sqlcoder-8b
       displayName: Llama 3 SQLCoder 8B L40S
       framework: vllm
       sha: vllm

--- a/models/public/gemma-2.yaml
+++ b/models/public/gemma-2.yaml
@@ -18,7 +18,7 @@ models:
     - label: Use Policy
       url: https://ai.google.dev/gemma/prohibited_use_policy
     optimizationProfiles:
-    - profileId: google/gemma-2-9b-a10g
+    - profileId: google/gemma-2-9b
       displayName: Gemma 2 9b A10G
       framework: vllm
       sha: vllm
@@ -31,7 +31,7 @@ models:
         value: A10G
       - key: COUNT
         value: 1
-    - profileId: google/gemma-2-9b-a100
+    - profileId: google/gemma-2-9b
       displayName: Gemma 2 A100
       framework: vllm
       sha: vllm
@@ -44,7 +44,7 @@ models:
         value: A100
       - key: COUNT
         value: 1
-    - profileId: google/gemma-2-9b-l40s
+    - profileId: google/gemma-2-9b
       displayName: Gemma 2 9b L40S
       framework: vllm
       sha: vllm

--- a/models/public/llama-3-sqlcoder-8b.yaml
+++ b/models/public/llama-3-sqlcoder-8b.yaml
@@ -17,7 +17,7 @@ models:
     - label: License Agreement
       url: https://choosealicense.com/licenses/cc-by-sa-4.0/
     optimizationProfiles:
-    - profileId: defog/llama-3-sqlcoder-8b-a10g
+    - profileId: defog/llama-3-sqlcoder-8b
       displayName: Llama 3 SQLCoder 8B A10G
       framework: vllm
       sha: vllm
@@ -27,7 +27,7 @@ models:
         value: A10G
       - key: COUNT
         value: 1
-    - profileId: defog/llama-3-sqlcoder-8b-a100
+    - profileId: defog/llama-3-sqlcoder-8b
       displayName: Llama 3 SQLCoder 8B A100
       framework: vllm
       sha: vllm
@@ -37,7 +37,7 @@ models:
         value: A100
       - key: COUNT
         value: 1
-    - profileId: defog/llama-3-sqlcoder-8b-l40s
+    - profileId: defog/llama-3-sqlcoder-8b
       displayName: Llama 3 SQLCoder 8B L40S
       framework: vllm
       sha: vllm


### PR DESCRIPTION
Keep the generated profile IDs stable for HF model entries across public, private, CSK, and airgapped catalogs. This avoids rewriting existing profile identifiers while updating the affected YAMLs so the published model definitions remain consistent across release folders.

Made-with: Cursor