### PR TITLE
DSE-55479: Make changes to generation script to ensure unique profile…

### DIFF
--- a/models/csk/1.57.0/parakeet-1-1b-ctc-en-us.yaml
+++ b/models/csk/1.57.0/parakeet-1-1b-ctc-en-us.yaml
@@ -137,7 +137,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-25.12.4-fp16-ikylnwwcjg
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-25.12.4-fp16-ikylnwwcjg__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline A100x1 Ofl Default
       ngcMetadata:
@@ -286,7 +286,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-25.12.4-fp8-ldxrqwxnow
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-25.12.4-fp8-ldxrqwxnow__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline H100x1 All Default
       ngcMetadata:
@@ -316,7 +316,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-silero-sortformer-25.12.4-fp16-irxmvxkjzq
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-silero-sortformer-25.12.4-fp16-irxmvxkjzq__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline A100x1 Ofl Silero Sortformer
       ngcMetadata:
@@ -376,7 +376,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-silero-sortformer-25.12.4-fp8-r1t-vaoajq
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-silero-sortformer-25.12.4-fp8-r1t-vaoajq__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline H100x1 Ofl Silero Sortformer
       ngcMetadata:
@@ -406,7 +406,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:dgx-sparkx1-ofl-25.12.4-fp16-vt0bruwfdg-dgx_spark
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:dgx-sparkx1-ofl-25.12.4-fp16-vt0bruwfdg-dgx_spark__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline DGX_SPARKx1 All Default
       ngcMetadata:
@@ -525,7 +525,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-25.12.4-fp8-nh6vnluohw
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-25.12.4-fp8-nh6vnluohw__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline L40Sx1 All Default
       ngcMetadata:
@@ -555,7 +555,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-silero-sortformer-25.12.4-fp8-18k-jihwrw
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-silero-sortformer-25.12.4-fp8-18k-jihwrw__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline L40Sx1 Ofl Silero Sortformer
       ngcMetadata:
@@ -585,7 +585,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:dgx-sparkx1-ofl-silero-sortformer-25.12.4-fp16-by3cdocosw-dgx_spark
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:dgx-sparkx1-ofl-silero-sortformer-25.12.4-fp16-by3cdocosw-dgx_spark__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline DGX_SPARKx1 Ofl Silero Sortformer
       ngcMetadata:
@@ -661,7 +661,7 @@ models:
         value: 3GB
       - key: MODEL TYPE
         value: RMIR
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:ofl-rmir-25.12.4
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:ofl-rmir-25.12.4__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline Generic NVIDIA GPUx1
       ngcMetadata:
@@ -707,7 +707,7 @@ models:
         value: 4GB
       - key: MODEL TYPE
         value: RMIR
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:ofl-silero-sortformer-rmir-25.12.4
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:ofl-silero-sortformer-rmir-25.12.4__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline Generic NVIDIA GPUx1
       ngcMetadata:

--- a/models/csk/1.58.0/parakeet-1-1b-ctc-en-us.yaml
+++ b/models/csk/1.58.0/parakeet-1-1b-ctc-en-us.yaml
@@ -137,7 +137,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-25.12.4-fp16-ikylnwwcjg
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-25.12.4-fp16-ikylnwwcjg__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline A100x1 Ofl Default
       ngcMetadata:
@@ -286,7 +286,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-25.12.4-fp8-ldxrqwxnow
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-25.12.4-fp8-ldxrqwxnow__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline H100x1 All Default
       ngcMetadata:
@@ -316,7 +316,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-silero-sortformer-25.12.4-fp16-irxmvxkjzq
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-silero-sortformer-25.12.4-fp16-irxmvxkjzq__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline A100x1 Ofl Silero Sortformer
       ngcMetadata:
@@ -376,7 +376,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-silero-sortformer-25.12.4-fp8-r1t-vaoajq
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-silero-sortformer-25.12.4-fp8-r1t-vaoajq__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline H100x1 Ofl Silero Sortformer
       ngcMetadata:
@@ -406,7 +406,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:dgx-sparkx1-ofl-25.12.4-fp16-vt0bruwfdg-dgx_spark
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:dgx-sparkx1-ofl-25.12.4-fp16-vt0bruwfdg-dgx_spark__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline DGX_SPARKx1 All Default
       ngcMetadata:
@@ -525,7 +525,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-25.12.4-fp8-nh6vnluohw
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-25.12.4-fp8-nh6vnluohw__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline L40Sx1 All Default
       ngcMetadata:
@@ -555,7 +555,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-silero-sortformer-25.12.4-fp8-18k-jihwrw
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-silero-sortformer-25.12.4-fp8-18k-jihwrw__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline L40Sx1 Ofl Silero Sortformer
       ngcMetadata:
@@ -585,7 +585,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:dgx-sparkx1-ofl-silero-sortformer-25.12.4-fp16-by3cdocosw-dgx_spark
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:dgx-sparkx1-ofl-silero-sortformer-25.12.4-fp16-by3cdocosw-dgx_spark__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline DGX_SPARKx1 Ofl Silero Sortformer
       ngcMetadata:
@@ -661,7 +661,7 @@ models:
         value: 3GB
       - key: MODEL TYPE
         value: RMIR
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:ofl-rmir-25.12.4
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:ofl-rmir-25.12.4__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline Generic NVIDIA GPUx1
       ngcMetadata:
@@ -707,7 +707,7 @@ models:
         value: 4GB
       - key: MODEL TYPE
         value: RMIR
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:ofl-silero-sortformer-rmir-25.12.4
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:ofl-silero-sortformer-rmir-25.12.4__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline Generic NVIDIA GPUx1
       ngcMetadata:

--- a/models/csk/parakeet-1-1b-ctc-en-us.yaml
+++ b/models/csk/parakeet-1-1b-ctc-en-us.yaml
@@ -137,7 +137,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-25.12.4-fp16-ikylnwwcjg
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-25.12.4-fp16-ikylnwwcjg__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline A100x1 Ofl Default
       ngcMetadata:
@@ -286,7 +286,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-25.12.4-fp8-ldxrqwxnow
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-25.12.4-fp8-ldxrqwxnow__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline H100x1 All Default
       ngcMetadata:
@@ -316,7 +316,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-silero-sortformer-25.12.4-fp16-irxmvxkjzq
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-silero-sortformer-25.12.4-fp16-irxmvxkjzq__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline A100x1 Ofl Silero Sortformer
       ngcMetadata:
@@ -376,7 +376,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-silero-sortformer-25.12.4-fp8-r1t-vaoajq
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-silero-sortformer-25.12.4-fp8-r1t-vaoajq__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline H100x1 Ofl Silero Sortformer
       ngcMetadata:
@@ -406,7 +406,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:dgx-sparkx1-ofl-25.12.4-fp16-vt0bruwfdg-dgx_spark
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:dgx-sparkx1-ofl-25.12.4-fp16-vt0bruwfdg-dgx_spark__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline DGX_SPARKx1 All Default
       ngcMetadata:
@@ -525,7 +525,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-25.12.4-fp8-nh6vnluohw
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-25.12.4-fp8-nh6vnluohw__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline L40Sx1 All Default
       ngcMetadata:
@@ -555,7 +555,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-silero-sortformer-25.12.4-fp8-18k-jihwrw
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-silero-sortformer-25.12.4-fp8-18k-jihwrw__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline L40Sx1 Ofl Silero Sortformer
       ngcMetadata:
@@ -585,7 +585,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:dgx-sparkx1-ofl-silero-sortformer-25.12.4-fp16-by3cdocosw-dgx_spark
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:dgx-sparkx1-ofl-silero-sortformer-25.12.4-fp16-by3cdocosw-dgx_spark__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline DGX_SPARKx1 Ofl Silero Sortformer
       ngcMetadata:
@@ -661,7 +661,7 @@ models:
         value: 3GB
       - key: MODEL TYPE
         value: RMIR
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:ofl-rmir-25.12.4
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:ofl-rmir-25.12.4__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline Generic NVIDIA GPUx1
       ngcMetadata:
@@ -707,7 +707,7 @@ models:
         value: 4GB
       - key: MODEL TYPE
         value: RMIR
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:ofl-silero-sortformer-rmir-25.12.4
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:ofl-silero-sortformer-rmir-25.12.4__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline Generic NVIDIA GPUx1
       ngcMetadata:

--- a/models/private/1.51.0-h2000/llama-3.1-instruct.yaml
+++ b/models/private/1.51.0-h2000/llama-3.1-instruct.yaml
@@ -197,7 +197,7 @@ models:
         value: 9GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__2
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct H200_NVLx1 BF16 Throughput
       ngcMetadata:
@@ -233,7 +233,7 @@ models:
         value: 30GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__3
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct RTX6000_ADAx1 INT4_AWQ Throughput
       ngcMetadata:
@@ -305,7 +305,7 @@ models:
         value: 16GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__4
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct GH200_480GBx1 BF16 Throughput
       ngcMetadata:
@@ -341,7 +341,7 @@ models:
         value: 30GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__5
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct A100_SXM4_40GBx1 BF16 Throughput
       ngcMetadata:
@@ -593,7 +593,7 @@ models:
         value: 6GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__6
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct H100_NVLx1 FP8 Throughput
       ngcMetadata:
@@ -665,7 +665,7 @@ models:
         value: 6GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__7
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct GH200_480GBx1 FP8 Latency
       ngcMetadata:
@@ -737,7 +737,7 @@ models:
         value: 9GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__8
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx1 NVFP4 Throughput
       ngcMetadata:
@@ -773,7 +773,7 @@ models:
         value: 30GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__9
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx1 FP8 Latency
       ngcMetadata:
@@ -809,7 +809,7 @@ models:
         value: 30GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__10
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct H200_NVLx2 BF16 Latency
       ngcMetadata:
@@ -845,7 +845,7 @@ models:
         value: 30GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__11
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct A100_SXM4_40GBx2 BF16 Latency
       ngcMetadata:
@@ -917,7 +917,7 @@ models:
         value: 16GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__12
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct H200_NVLx2 FP8 Latency
       ngcMetadata:
@@ -1025,7 +1025,7 @@ models:
         value: 16GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__13
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct GH200_144GBx1 BF16 Throughput
       ngcMetadata:
@@ -1097,7 +1097,7 @@ models:
         value: 9GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__14
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx1 NVFP4 Latency
       ngcMetadata:
@@ -1133,7 +1133,7 @@ models:
         value: 30GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__15
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct H200_NVLx1 FP8 Throughput
       ngcMetadata:
@@ -1349,7 +1349,7 @@ models:
         value: 6GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__16
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct H100_NVLx2 BF16 Latency
       ngcMetadata:
@@ -1385,7 +1385,7 @@ models:
         value: 30GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__17
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct GH200_144GBx1 FP8 Throughput
       ngcMetadata:
@@ -1457,7 +1457,7 @@ models:
         value: 16GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__18
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct GH200_480GBx1 BF16 Latency
       ngcMetadata:
@@ -1529,7 +1529,7 @@ models:
         value: 9GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__19
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct RTX6000_ADAx1 INT4_AWQ Latency
       ngcMetadata:
@@ -1565,7 +1565,7 @@ models:
         value: 30GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__20
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx1 BF16 Latency
       ngcMetadata:
@@ -1601,7 +1601,7 @@ models:
         value: 30GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__21
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx1 BF16 Throughput
       ngcMetadata:
@@ -1673,7 +1673,7 @@ models:
         value: 16GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__22
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct GH200_144GBx1 BF16 Latency
       ngcMetadata:
@@ -1745,7 +1745,7 @@ models:
         value: 9GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__23
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct H100_NVLx1 BF16 Throughput
       ngcMetadata:
@@ -1781,7 +1781,7 @@ models:
         value: 30GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__24
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct GH200_480GBx1 FP8 Throughput
       ngcMetadata:
@@ -1817,7 +1817,7 @@ models:
         value: 30GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__25
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx1 FP8 Throughput
       ngcMetadata:
@@ -1889,7 +1889,7 @@ models:
         value: 16GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__26
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct GH200_144GBx1 FP8 Latency
       ngcMetadata:
@@ -2074,7 +2074,7 @@ models:
         value: 139GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__2
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct A100_SXM4_40GBx8 BF16 Throughput
       ngcMetadata:
@@ -2182,7 +2182,7 @@ models:
         value: 41GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__3
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx2 FP8 Throughput
       ngcMetadata:
@@ -2218,7 +2218,7 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__4
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct H100_NVLx2 BF16 Throughput
       ngcMetadata:
@@ -2326,7 +2326,7 @@ models:
         value: 69GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__5
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct H100_NVLx2 FP8 Throughput
       ngcMetadata:
@@ -2398,7 +2398,7 @@ models:
         value: 134GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__6
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx2 NVFP4 Throughput
       ngcMetadata:
@@ -2506,7 +2506,7 @@ models:
         value: 69GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__7
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct GH200_144GBx2 BF16 Latency
       ngcMetadata:
@@ -2542,7 +2542,7 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__8
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct H200_NVLx2 FP8 Latency
       ngcMetadata:
@@ -2578,7 +2578,7 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__9
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct GH200_144GBx1 FP8 Throughput
       ngcMetadata:
@@ -2758,7 +2758,7 @@ models:
         value: 68GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__10
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct GH200_480GBx1 FP8 Throughput
       ngcMetadata:
@@ -2794,7 +2794,7 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__11
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx4 BF16 Throughput
       ngcMetadata:
@@ -2866,7 +2866,7 @@ models:
         value: 147GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__12
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct GH200_480GBx1 FP8 Latency
       ngcMetadata:
@@ -2974,7 +2974,7 @@ models:
         value: 69GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__13
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct H200_NVLx1 FP8 Throughput
       ngcMetadata:
@@ -3082,7 +3082,7 @@ models:
         value: 69GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__14
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct H100_NVLx4 FP8 Latency
       ngcMetadata:
@@ -3118,7 +3118,7 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__15
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct GH200_144GBx2 BF16 Throughput
       ngcMetadata:
@@ -3190,7 +3190,7 @@ models:
         value: 150GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__16
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct GH200_144GBx2 FP8 Latency
       ngcMetadata:
@@ -3262,7 +3262,7 @@ models:
         value: 68GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__17
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct GH200_144GBx2 FP8 Throughput
       ngcMetadata:
@@ -3298,7 +3298,7 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__18
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct A100_SXM4_40GBx8 BF16 Latency
       ngcMetadata:
@@ -3406,7 +3406,7 @@ models:
         value: 138GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__19
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct H100_NVLx4 BF16 Latency
       ngcMetadata:
@@ -3550,7 +3550,7 @@ models:
         value: 150GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__20
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx4 NVFP4 Latency
       ngcMetadata:
@@ -3622,7 +3622,7 @@ models:
         value: 134GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__21
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx4 FP8 Latency
       ngcMetadata:
@@ -3658,7 +3658,7 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__22
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct H200_NVLx2 BF16 Throughput
       ngcMetadata:

--- a/models/private/1.51.0-h2000/llama-3.1-nemotron-nano-v1.yaml
+++ b/models/private/1.51.0-h2000/llama-3.1-nemotron-nano-v1.yaml
@@ -227,7 +227,7 @@ models:
         value: 6GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama3.1-nemotron-nano-4b-v1.1:hf-9f834a8-fix-checksum
+    - profileId: nim/nvidia/llama3.1-nemotron-nano-4b-v1.1:hf-9f834a8-fix-checksum__2
       framework: TensorRT-LLM
       displayName: Llama 3.1 Nemotron Nano 4B V1.1 A100_SXM4_40GBx1 BF16 Throughput
       ngcMetadata:
@@ -297,7 +297,7 @@ models:
         value: 9GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama3.1-nemotron-nano-4b-v1.1:hf-9f834a8-fix-checksum
+    - profileId: nim/nvidia/llama3.1-nemotron-nano-4b-v1.1:hf-9f834a8-fix-checksum__3
       framework: TensorRT-LLM
       displayName: Llama 3.1 Nemotron Nano 4B V1.1 GH200_480GBx1 BF16 Throughput
       ngcMetadata:
@@ -332,7 +332,7 @@ models:
         value: 9GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama3.1-nemotron-nano-4b-v1.1:hf-9f834a8-fix-checksum
+    - profileId: nim/nvidia/llama3.1-nemotron-nano-4b-v1.1:hf-9f834a8-fix-checksum__4
       framework: TensorRT-LLM
       displayName: Llama 3.1 Nemotron Nano 4B V1.1 Generic NVIDIA GPUx2 BF16
       ngcMetadata:
@@ -360,7 +360,7 @@ models:
         value: TENSORRT_LLM
       - key: TRTLLM BUILDABLE
         value: 'TRUE'
-    - profileId: nim/nvidia/llama3.1-nemotron-nano-4b-v1.1:hf-9f834a8-fix-checksum
+    - profileId: nim/nvidia/llama3.1-nemotron-nano-4b-v1.1:hf-9f834a8-fix-checksum__5
       framework: TensorRT-LLM
       displayName: Llama 3.1 Nemotron Nano 4B V1.1 Generic NVIDIA GPUx1 BF16
       ngcMetadata:
@@ -525,7 +525,7 @@ models:
         value: 1.8.4
       - key: DOWNLOAD SIZE
         value: 16GB
-    - profileId: nim/nvidia/llama-3.1-nemotron-nano-8b-v1:hf-25.03.17-0508-tool-use-v2
+    - profileId: nim/nvidia/llama-3.1-nemotron-nano-8b-v1:hf-25.03.17-0508-tool-use-v2__2
       framework: TensorRT-LLM
       displayName: Llama 3.1 Nemotron Nano 8B V1 H100_NVLx1 FP8 Throughput
       ngcMetadata:
@@ -756,7 +756,7 @@ models:
         value: 1.8.4
       - key: DOWNLOAD SIZE
         value: 17GB
-    - profileId: nim/nvidia/llama-3.1-nemotron-nano-8b-v1:hf-25.03.17-0508-tool-use-v2
+    - profileId: nim/nvidia/llama-3.1-nemotron-nano-8b-v1:hf-25.03.17-0508-tool-use-v2__3
       framework: TensorRT-LLM
       displayName: Llama 3.1 Nemotron Nano 8B V1 H100_NVLx2 FP8 Latency
       ngcMetadata:
@@ -921,7 +921,7 @@ models:
         value: 1.8.4
       - key: DOWNLOAD SIZE
         value: 17GB
-    - profileId: nim/nvidia/llama-3.1-nemotron-nano-8b-v1:hf-25.03.17-0508-tool-use-v2
+    - profileId: nim/nvidia/llama-3.1-nemotron-nano-8b-v1:hf-25.03.17-0508-tool-use-v2__4
       framework: TensorRT-LLM
       displayName: Llama 3.1 Nemotron Nano 8B V1 H100_NVLx2 BF16 Latency
       ngcMetadata:
@@ -1086,7 +1086,7 @@ models:
         value: 1.8.4
       - key: DOWNLOAD SIZE
         value: 17GB
-    - profileId: nim/nvidia/llama-3.1-nemotron-nano-8b-v1:hf-25.03.17-0508-tool-use-v2
+    - profileId: nim/nvidia/llama-3.1-nemotron-nano-8b-v1:hf-25.03.17-0508-tool-use-v2__5
       framework: TensorRT-LLM
       displayName: Llama 3.1 Nemotron Nano 8B V1 Generic NVIDIA GPUx2 BF16
       ngcMetadata:
@@ -1110,7 +1110,7 @@ models:
         value: 1.8.4
       - key: DOWNLOAD SIZE
         value: 15GB
-    - profileId: nim/nvidia/llama-3.1-nemotron-nano-8b-v1:hf-25.03.17-0508-tool-use-v2
+    - profileId: nim/nvidia/llama-3.1-nemotron-nano-8b-v1:hf-25.03.17-0508-tool-use-v2__6
       framework: TensorRT-LLM
       displayName: Llama 3.1 Nemotron Nano 8B V1 Generic NVIDIA GPUx4 BF16
       ngcMetadata:
@@ -1134,7 +1134,7 @@ models:
         value: 1.8.4
       - key: DOWNLOAD SIZE
         value: 15GB
-    - profileId: nim/nvidia/llama-3.1-nemotron-nano-8b-v1:hf-25.03.17-0508-tool-use-v2
+    - profileId: nim/nvidia/llama-3.1-nemotron-nano-8b-v1:hf-25.03.17-0508-tool-use-v2__7
       framework: TensorRT-LLM
       displayName: Llama 3.1 Nemotron Nano 8B V1 Generic NVIDIA GPUx1 BF16
       ngcMetadata:

--- a/models/private/1.51.0-h2000/llama-3.2-instruct.yaml
+++ b/models/private/1.51.0-h2000/llama-3.2-instruct.yaml
@@ -197,7 +197,7 @@ models:
         value: 5GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__2
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct H100_NVLx1 BF16 Throughput
       ngcMetadata:
@@ -233,7 +233,7 @@ models:
         value: 5GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__3
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct GH200_144GBx1 FP8 Latency
       ngcMetadata:
@@ -305,7 +305,7 @@ models:
         value: 3GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__4
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct RTX6000_BLACKWELL_SVx1 FP8 Latency
       ngcMetadata:
@@ -341,7 +341,7 @@ models:
         value: 5GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__5
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct RTX6000_BLACKWELL_SVx1 BF16 Throughput
       ngcMetadata:
@@ -377,7 +377,7 @@ models:
         value: 5GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__6
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct H200_NVLx1 FP8 Throughput
       ngcMetadata:
@@ -413,7 +413,7 @@ models:
         value: 5GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__7
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct H200_NVLx1 BF16 Throughput
       ngcMetadata:
@@ -449,7 +449,7 @@ models:
         value: 5GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__8
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct H100_NVLx1 FP8 Throughput
       ngcMetadata:
@@ -485,7 +485,7 @@ models:
         value: 5GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__9
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct H200_NVLx2 FP8 Latency
       ngcMetadata:
@@ -593,7 +593,7 @@ models:
         value: 4GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__10
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct A100_SXM4_40GBx2 BF16 Latency
       ngcMetadata:
@@ -629,7 +629,7 @@ models:
         value: 5GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__11
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct GH200_144GBx1 BF16 Latency
       ngcMetadata:
@@ -665,7 +665,7 @@ models:
         value: 5GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__12
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct A100_SXM4_40GBx1 BF16 Throughput
       ngcMetadata:
@@ -881,7 +881,7 @@ models:
         value: 2GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__13
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct GH200_480GBx1 FP8 Throughput
       ngcMetadata:
@@ -917,7 +917,7 @@ models:
         value: 5GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__14
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct H200_NVLx2 BF16 Latency
       ngcMetadata:
@@ -989,7 +989,7 @@ models:
         value: 4GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__15
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct RTX6000_BLACKWELL_SVx1 FP8 Throughput
       ngcMetadata:
@@ -1133,7 +1133,7 @@ models:
         value: 4GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__16
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct GH200_480GBx1 BF16 Throughput
       ngcMetadata:
@@ -1313,7 +1313,7 @@ models:
         value: 4GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__17
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct GH200_144GBx1 FP8 Throughput
       ngcMetadata:
@@ -1385,7 +1385,7 @@ models:
         value: 4GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__18
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct H100_NVLx2 FP8 Latency
       ngcMetadata:
@@ -1457,7 +1457,7 @@ models:
         value: 2GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__19
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct GH200_144GBx1 BF16 Throughput
       ngcMetadata:
@@ -1601,7 +1601,7 @@ models:
         value: 3GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__20
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct H100_NVLx2 BF16 Latency
       ngcMetadata:
@@ -1817,7 +1817,7 @@ models:
         value: 12GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2
+    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2__2
       framework: TensorRT-LLM
       displayName: Llama 3.2 3B Instruct A100_SXM4_40GBx2 BF16 Latency
       ngcMetadata:
@@ -1992,7 +1992,7 @@ models:
         value: 5GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2
+    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2__3
       framework: TensorRT-LLM
       displayName: Llama 3.2 3B Instruct RTX6000_ADAx1 BF16 Latency
       ngcMetadata:
@@ -2027,7 +2027,7 @@ models:
         value: 12GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2
+    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2__4
       framework: TensorRT-LLM
       displayName: Llama 3.2 3B Instruct H100_NVLx1 FP8 Throughput
       ngcMetadata:
@@ -2237,7 +2237,7 @@ models:
         value: 5GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2
+    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2__5
       framework: TensorRT-LLM
       displayName: Llama 3.2 3B Instruct RTX6000_ADAx1 FP8 Throughput
       ngcMetadata:
@@ -2377,7 +2377,7 @@ models:
         value: 7GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2
+    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2__6
       framework: TensorRT-LLM
       displayName: Llama 3.2 3B Instruct H100_NVLx2 FP8 Latency
       ngcMetadata:
@@ -2412,7 +2412,7 @@ models:
         value: 12GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2
+    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2__7
       framework: TensorRT-LLM
       displayName: Llama 3.2 3B Instruct RTX6000_ADAx1 FP8 Latency
       ngcMetadata:
@@ -2482,7 +2482,7 @@ models:
         value: 7GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2
+    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2__8
       framework: TensorRT-LLM
       displayName: Llama 3.2 3B Instruct RTX6000_ADAx1 BF16 Throughput
       ngcMetadata:
@@ -2657,7 +2657,7 @@ models:
         value: 8GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2
+    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2__9
       framework: TensorRT-LLM
       displayName: Llama 3.2 3B Instruct H100_NVLx2 BF16 Latency
       ngcMetadata:
@@ -2797,7 +2797,7 @@ models:
         value: 5GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2
+    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2__10
       framework: TensorRT-LLM
       displayName: Llama 3.2 3B Instruct A100_SXM4_40GBx1 BF16 Throughput
       ngcMetadata:
@@ -3042,7 +3042,7 @@ models:
         value: 8GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2
+    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2__11
       framework: TensorRT-LLM
       displayName: Llama 3.2 3B Instruct GH200_480GBx1 FP8 Throughput
       ngcMetadata:
@@ -3112,7 +3112,7 @@ models:
         value: 7GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2
+    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2__12
       framework: TensorRT-LLM
       displayName: Llama 3.2 3B Instruct GH200_480GBx1 BF16 Throughput
       ngcMetadata:

--- a/models/private/1.51.0-h2000/llama-3.2-nv-rerankqa-v2.yaml
+++ b/models/private/1.51.0-h2000/llama-3.2-nv-rerankqa-v2.yaml
@@ -110,7 +110,7 @@ models:
         value: TENSORRT
       - key: MODEL TYPE
         value: TENSORRT
-    - profileId: nim/nvidia/llama-3.2-nv-rerankqa-1b-v2:a100x1-trt-fp16-dxtbz8wstg
+    - profileId: nim/nvidia/llama-3.2-nv-rerankqa-1b-v2:a100x1-trt-fp16-dxtbz8wstg__2
       framework: TensorRT-LLM
       displayName: Llama 3.2 NV Rerankqa 1B V2 NVIDIA A100-SXM4-80GBx1 FP16
       ngcMetadata:
@@ -327,7 +327,7 @@ models:
         value: TENSORRT
       - key: MODEL TYPE
         value: TENSORRT
-    - profileId: nim/nvidia/llama-3.2-nv-rerankqa-1b-v2:h100x1-trt-fp8-bm87q6egvq
+    - profileId: nim/nvidia/llama-3.2-nv-rerankqa-1b-v2:h100x1-trt-fp8-bm87q6egvq__2
       framework: TensorRT-LLM
       displayName: Llama 3.2 NV Rerankqa 1B V2 NVIDIA H100 NVLx1 FP8
       ngcMetadata:
@@ -358,7 +358,7 @@ models:
         value: TENSORRT
       - key: MODEL TYPE
         value: TENSORRT
-    - profileId: nim/nvidia/llama-3.2-nv-rerankqa-1b-v2:h100x1-trt-fp16--ckqlv3j2g
+    - profileId: nim/nvidia/llama-3.2-nv-rerankqa-1b-v2:h100x1-trt-fp16--ckqlv3j2g__2
       framework: TensorRT-LLM
       displayName: Llama 3.2 NV Rerankqa 1B V2 NVIDIA H100 80GB HBM3x1 FP16
       ngcMetadata:

--- a/models/private/1.51.0-h2000/llama-3.3-instruct.yaml
+++ b/models/private/1.51.0-h2000/llama-3.3-instruct.yaml
@@ -269,7 +269,7 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__2
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct A100_SXM4_40GBx8 BF16 Throughput
       ngcMetadata:
@@ -305,7 +305,7 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__3
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct H100_NVLx2 BF16 Throughput
       ngcMetadata:
@@ -377,7 +377,7 @@ models:
         value: 69GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__4
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct GH200_144GBx2 BF16 Throughput
       ngcMetadata:
@@ -485,7 +485,7 @@ models:
         value: 147GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__5
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct GH200_144GBx2 FP8 Latency
       ngcMetadata:
@@ -521,7 +521,7 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__6
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct GH200_144GBx2 FP8 Throughput
       ngcMetadata:
@@ -629,7 +629,7 @@ models:
         value: 69GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__7
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct GH200_144GBx1 FP8 Throughput
       ngcMetadata:
@@ -665,7 +665,7 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__8
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct GH200_480GBx1 FP8 Latency
       ngcMetadata:
@@ -773,7 +773,7 @@ models:
         value: 134GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__9
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx8 BF16 Latency
       ngcMetadata:
@@ -953,7 +953,7 @@ models:
         value: 69GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__10
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct A100_SXM4_40GBx8 BF16 Latency
       ngcMetadata:
@@ -989,7 +989,7 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__11
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct H200_NVLx1 FP8 Throughput
       ngcMetadata:
@@ -1169,7 +1169,7 @@ models:
         value: 69GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__12
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx4 BF16 Throughput
       ngcMetadata:
@@ -1241,7 +1241,7 @@ models:
         value: 68GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__13
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct GH200_144GBx2 BF16 Latency
       ngcMetadata:
@@ -1277,7 +1277,7 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__14
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx2 FP8 Throughput
       ngcMetadata:
@@ -1349,7 +1349,7 @@ models:
         value: 68GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__15
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct GH200_480GBx1 FP8 Throughput
       ngcMetadata:
@@ -1421,7 +1421,7 @@ models:
         value: 69GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__16
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct H200_NVLx2 FP8 Latency
       ngcMetadata:
@@ -1457,7 +1457,7 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__17
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx2 NVFP4 Throughput
       ngcMetadata:
@@ -1565,7 +1565,7 @@ models:
         value: 134GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__18
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct H100_NVLx2 FP8 Throughput
       ngcMetadata:
@@ -1637,7 +1637,7 @@ models:
         value: 138GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__19
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx4 FP8 Latency
       ngcMetadata:
@@ -1673,7 +1673,7 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__20
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct H100_NVLx4 BF16 Latency
       ngcMetadata:
@@ -1745,7 +1745,7 @@ models:
         value: 68GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__21
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx4 NVFP4 Latency
       ngcMetadata:
@@ -1817,7 +1817,7 @@ models:
         value: 139GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__22
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct H100_NVLx4 FP8 Latency
       ngcMetadata:

--- a/models/private/1.51.0-h2000/llama-3.3-nemotron-super-49b-v1.yaml
+++ b/models/private/1.51.0-h2000/llama-3.3-nemotron-super-49b-v1.yaml
@@ -227,7 +227,7 @@ models:
         value: 49GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1:hf-1a2cb80-nim-0613-tool-use-v2
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1:hf-1a2cb80-nim-0613-tool-use-v2__2
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1 H100_NVLx1 FP8 Throughput
       ngcMetadata:
@@ -297,7 +297,7 @@ models:
         value: 96GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1:hf-1a2cb80-nim-0613-tool-use-v2
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1:hf-1a2cb80-nim-0613-tool-use-v2__3
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1 A100_SXM4_40GBx4 BF16 Throughput
       ngcMetadata:
@@ -437,7 +437,7 @@ models:
         value: 49GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1:hf-1a2cb80-nim-0613-tool-use-v2
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1:hf-1a2cb80-nim-0613-tool-use-v2__4
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1 A100_SXM4_40GBx8 BF16 Latency
       ngcMetadata:
@@ -472,7 +472,7 @@ models:
         value: 93GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1:hf-1a2cb80-nim-0613-tool-use-v2
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1:hf-1a2cb80-nim-0613-tool-use-v2__5
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1 H100_NVLx2 FP8 Latency
       ngcMetadata:
@@ -542,7 +542,7 @@ models:
         value: 93GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1:hf-1a2cb80-nim-0613-tool-use-v2
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1:hf-1a2cb80-nim-0613-tool-use-v2__6
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1 H100_NVLx2 BF16 Throughput
       ngcMetadata:
@@ -752,7 +752,7 @@ models:
         value: 96GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1:hf-1a2cb80-nim-0613-tool-use-v2
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1:hf-1a2cb80-nim-0613-tool-use-v2__7
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1 Generic NVIDIA GPUx8 BF16
       ngcMetadata:
@@ -780,7 +780,7 @@ models:
         value: TENSORRT_LLM
       - key: TRTLLM BUILDABLE
         value: 'TRUE'
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1:hf-1a2cb80-nim-0613-tool-use-v2
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1:hf-1a2cb80-nim-0613-tool-use-v2__8
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1 Generic NVIDIA GPUx2 BF16
       ngcMetadata:
@@ -808,7 +808,7 @@ models:
         value: TENSORRT_LLM
       - key: TRTLLM BUILDABLE
         value: 'TRUE'
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1:hf-1a2cb80-nim-0613-tool-use-v2
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1:hf-1a2cb80-nim-0613-tool-use-v2__9
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1 Generic NVIDIA GPUx4 BF16
       ngcMetadata:
@@ -1165,7 +1165,7 @@ models:
         value: 30GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__2
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 A100_SXM4_40GBx4 BF16 Throughput
       ngcMetadata:
@@ -1201,7 +1201,7 @@ models:
         value: 93GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__3
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx1 FP8 Throughput
       ngcMetadata:
@@ -1237,7 +1237,7 @@ models:
         value: 93GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__4
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 H200_NVLx1 FP8 Throughput
       ngcMetadata:
@@ -1309,7 +1309,7 @@ models:
         value: 94GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__5
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx2 NVFP4 Throughput
       ngcMetadata:
@@ -1381,7 +1381,7 @@ models:
         value: 96GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__6
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 H100_NVLx1 FP8 Throughput
       ngcMetadata:
@@ -1417,7 +1417,7 @@ models:
         value: 93GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__7
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 GH200_144GBx1 BF16 Throughput
       ngcMetadata:
@@ -1453,7 +1453,7 @@ models:
         value: 93GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__8
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx1 NVFP4 Throughput
       ngcMetadata:
@@ -1489,7 +1489,7 @@ models:
         value: 93GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__9
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 H100_NVLx2 BF16 Throughput
       ngcMetadata:
@@ -1633,7 +1633,7 @@ models:
         value: 100GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__10
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx2 NVFP4 Latency
       ngcMetadata:
@@ -1669,7 +1669,7 @@ models:
         value: 93GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__11
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 H100_NVLx2 FP8 Latency
       ngcMetadata:
@@ -1741,7 +1741,7 @@ models:
         value: 94GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__12
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx2 FP8 Latency
       ngcMetadata:
@@ -1777,7 +1777,7 @@ models:
         value: 93GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__13
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 GH200_480GBx1 FP8 Throughput
       ngcMetadata:
@@ -1957,7 +1957,7 @@ models:
         value: 100GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__14
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 H200_NVLx2 BF16 Latency
       ngcMetadata:
@@ -2065,7 +2065,7 @@ models:
         value: 49GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__15
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 H200_NVLx2 FP8 Latency
       ngcMetadata:
@@ -2137,7 +2137,7 @@ models:
         value: 49GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__16
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 H200_NVLx1 BF16 Throughput
       ngcMetadata:
@@ -2209,7 +2209,7 @@ models:
         value: 49GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__17
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 GH200_144GBx2 FP8 Latency
       ngcMetadata:
@@ -2245,7 +2245,7 @@ models:
         value: 93GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__18
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 H100_NVLx4 BF16 Latency
       ngcMetadata:
@@ -2281,7 +2281,7 @@ models:
         value: 93GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__19
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 A100_SXM4_40GBx8 BF16 Latency
       ngcMetadata:
@@ -2317,7 +2317,7 @@ models:
         value: 93GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__20
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx2 BF16 Throughput
       ngcMetadata:
@@ -2425,7 +2425,7 @@ models:
         value: 49GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__21
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 GH200_144GBx2 BF16 Latency
       ngcMetadata:
@@ -2569,7 +2569,7 @@ models:
         value: 49GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__22
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 GH200_144GBx1 FP8 Throughput
       ngcMetadata:

--- a/models/private/1.51.0-h2000/mistral-instruct.yaml
+++ b/models/private/1.51.0-h2000/mistral-instruct.yaml
@@ -120,7 +120,7 @@ models:
         value: 8GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__2
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 H200_NVLx2 BF16 Latency
       ngcMetadata:
@@ -192,7 +192,7 @@ models:
         value: 8GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__3
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 RTX6000_BLACKWELL_SVx1 BF16 Latency
       ngcMetadata:
@@ -264,7 +264,7 @@ models:
         value: 14GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__4
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 A100_SXM4_40GBx2 BF16 Latency
       ngcMetadata:
@@ -336,7 +336,7 @@ models:
         value: 14GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__5
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 GH200_144GBx1 BF16 Throughput
       ngcMetadata:
@@ -372,7 +372,7 @@ models:
         value: 28GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__6
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 GH200_144GBx1 BF16 Latency
       ngcMetadata:
@@ -408,7 +408,7 @@ models:
         value: 28GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__7
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 GH200_144GBx1 FP8 Throughput
       ngcMetadata:
@@ -516,7 +516,7 @@ models:
         value: 14GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__8
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 H100_NVLx1 FP8 Throughput
       ngcMetadata:
@@ -588,7 +588,7 @@ models:
         value: 14GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__9
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 H100_NVLx2 FP8 Latency
       ngcMetadata:
@@ -696,7 +696,7 @@ models:
         value: 8GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__10
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 GH200_144GBx1 FP8 Latency
       ngcMetadata:
@@ -732,7 +732,7 @@ models:
         value: 28GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__11
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 GH200_480GBx1 BF16 Latency
       ngcMetadata:
@@ -768,7 +768,7 @@ models:
         value: 28GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__12
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 RTX6000_BLACKWELL_SVx1 FP8 Throughput
       ngcMetadata:
@@ -876,7 +876,7 @@ models:
         value: 14GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__13
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 H200_NVLx1 FP8 Throughput
       ngcMetadata:
@@ -912,7 +912,7 @@ models:
         value: 28GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__14
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 H100_NVLx1 BF16 Throughput
       ngcMetadata:
@@ -948,7 +948,7 @@ models:
         value: 28GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__15
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 GH200_480GBx1 BF16 Throughput
       ngcMetadata:
@@ -1128,7 +1128,7 @@ models:
         value: 14GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__16
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 A100_SXM4_40GBx1 BF16 Throughput
       ngcMetadata:
@@ -1164,7 +1164,7 @@ models:
         value: 28GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__17
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 GH200_480GBx1 FP8 Latency
       ngcMetadata:
@@ -1200,7 +1200,7 @@ models:
         value: 28GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__18
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 RTX6000_BLACKWELL_SVx1 FP8 Latency
       ngcMetadata:
@@ -1380,7 +1380,7 @@ models:
         value: 8GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__19
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 GH200_480GBx1 FP8 Throughput
       ngcMetadata:
@@ -1416,7 +1416,7 @@ models:
         value: 28GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__20
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 RTX6000_BLACKWELL_SVx1 BF16 Throughput
       ngcMetadata:
@@ -1452,7 +1452,7 @@ models:
         value: 28GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__21
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 H200_NVLx2 FP8 Latency
       ngcMetadata:
@@ -1596,7 +1596,7 @@ models:
         value: 8GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__22
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 H100_NVLx2 BF16 Latency
       ngcMetadata:

--- a/models/private/1.51.0-h2000/mixtral-instruct.yaml
+++ b/models/private/1.51.0-h2000/mixtral-instruct.yaml
@@ -222,7 +222,7 @@ models:
         value: 44GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mixtral-8x7b-instruct-v01:hf-a60832c-0508-tool-use-v2
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v01:hf-a60832c-0508-tool-use-v2__2
       framework: TensorRT-LLM
       displayName: Mixtral 8x7b Instruct V0.1 H100_NVLx1 FP8 Throughput
       ngcMetadata:
@@ -292,7 +292,7 @@ models:
         value: 88GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mixtral-8x7b-instruct-v01:hf-a60832c-0508-tool-use-v2
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v01:hf-a60832c-0508-tool-use-v2__3
       framework: TensorRT-LLM
       displayName: Mixtral 8x7b Instruct V0.1 A100_SXM4_40GBx4 BF16 Throughput
       ngcMetadata:
@@ -467,7 +467,7 @@ models:
         value: 88GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mixtral-8x7b-instruct-v01:hf-a60832c-0508-tool-use-v2
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v01:hf-a60832c-0508-tool-use-v2__4
       framework: TensorRT-LLM
       displayName: Mixtral 8x7b Instruct V0.1 A100_SXM4_40GBx8 BF16 Latency
       ngcMetadata:
@@ -572,7 +572,7 @@ models:
         value: 90GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mixtral-8x7b-instruct-v01:hf-a60832c-0508-tool-use-v2
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v01:hf-a60832c-0508-tool-use-v2__5
       framework: TensorRT-LLM
       displayName: Mixtral 8x7b Instruct V0.1 H100_NVLx2 FP8 Latency
       ngcMetadata:
@@ -677,7 +677,7 @@ models:
         value: 88GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mixtral-8x7b-instruct-v01:hf-a60832c-0508-tool-use-v2
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v01:hf-a60832c-0508-tool-use-v2__6
       framework: TensorRT-LLM
       displayName: Mixtral 8x7b Instruct V0.1 H100_NVLx2 BF16 Throughput
       ngcMetadata:
@@ -887,7 +887,7 @@ models:
         value: 88GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mixtral-8x7b-instruct-v01:hf-a60832c-0508-tool-use-v2
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v01:hf-a60832c-0508-tool-use-v2__7
       framework: TensorRT-LLM
       displayName: Mixtral 8x7b Instruct V0.1 Generic NVIDIA GPUx8 BF16
       ngcMetadata:
@@ -915,7 +915,7 @@ models:
         value: TENSORRT_LLM
       - key: TRTLLM BUILDABLE
         value: 'TRUE'
-    - profileId: nim/mistralai/mixtral-8x7b-instruct-v01:hf-a60832c-0508-tool-use-v2
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v01:hf-a60832c-0508-tool-use-v2__8
       framework: TensorRT-LLM
       displayName: Mixtral 8x7b Instruct V0.1 Generic NVIDIA GPUx2 BF16
       ngcMetadata:
@@ -943,7 +943,7 @@ models:
         value: TENSORRT_LLM
       - key: TRTLLM BUILDABLE
         value: 'TRUE'
-    - profileId: nim/mistralai/mixtral-8x7b-instruct-v01:hf-a60832c-0508-tool-use-v2
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v01:hf-a60832c-0508-tool-use-v2__9
       framework: TensorRT-LLM
       displayName: Mixtral 8x7b Instruct V0.1 Generic NVIDIA GPUx4 BF16
       ngcMetadata:

--- a/models/private/1.51.0-h2000/paddleocr.yaml
+++ b/models/private/1.51.0-h2000/paddleocr.yaml
@@ -79,7 +79,7 @@ models:
         value: TRITON
       - key: MODEL TYPE
         value: TENSORRT
-    - profileId: nim/baidu/paddleocr:2_TRT_python_2
+    - profileId: nim/baidu/paddleocr:2_TRT_python_2__2
       framework: TensorRT-LLM
       displayName: Paddleocr NVIDIA H100 NVLx1 FP16
       ngcMetadata:
@@ -141,7 +141,7 @@ models:
         value: TRITON
       - key: MODEL TYPE
         value: TENSORRT
-    - profileId: nim/baidu/paddleocr:2_TRT_python_2
+    - profileId: nim/baidu/paddleocr:2_TRT_python_2__3
       framework: TensorRT-LLM
       displayName: Paddleocr NVIDIA A100-SXM4-40GBx1 FP16
       ngcMetadata:
@@ -234,7 +234,7 @@ models:
         value: TRITON
       - key: MODEL TYPE
         value: TENSORRT
-    - profileId: nim/baidu/paddleocr:2_TRT_python_2
+    - profileId: nim/baidu/paddleocr:2_TRT_python_2__4
       framework: TensorRT-LLM
       displayName: Paddleocr NVIDIA H100 80GB HBM3x1 FP16
       ngcMetadata:

--- a/models/private/1.51.0-h2100/llama-3-sqlcoder-8b.yaml
+++ b/models/private/1.51.0-h2100/llama-3-sqlcoder-8b.yaml
@@ -27,7 +27,7 @@ models:
             value: A10G
           - key: COUNT
             value: 1
-        - profileId: defog/llama-3-sqlcoder-8b
+        - profileId: defog/llama-3-sqlcoder-8b__2
           displayName: Llama 3 SQLCoder 8B A100
           framework: vllm
           sha: vllm
@@ -37,7 +37,7 @@ models:
             value: A100
           - key: COUNT
             value: 1
-        - profileId: defog/llama-3-sqlcoder-8b
+        - profileId: defog/llama-3-sqlcoder-8b__3
           displayName: Llama 3 SQLCoder 8B L40S
           framework: vllm
           sha: vllm

--- a/models/private/1.51.0-h2100/llama-3.1-instruct.yaml
+++ b/models/private/1.51.0-h2100/llama-3.1-instruct.yaml
@@ -197,7 +197,7 @@ models:
         value: 9GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__2
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct H200_NVLx1 BF16 Throughput
       ngcMetadata:
@@ -233,7 +233,7 @@ models:
         value: 30GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__3
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct RTX6000_ADAx1 INT4_AWQ Throughput
       ngcMetadata:
@@ -305,7 +305,7 @@ models:
         value: 16GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__4
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct GH200_480GBx1 BF16 Throughput
       ngcMetadata:
@@ -341,7 +341,7 @@ models:
         value: 30GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__5
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct A100_SXM4_40GBx1 BF16 Throughput
       ngcMetadata:
@@ -593,7 +593,7 @@ models:
         value: 6GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__6
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct H100_NVLx1 FP8 Throughput
       ngcMetadata:
@@ -665,7 +665,7 @@ models:
         value: 6GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__7
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct GH200_480GBx1 FP8 Latency
       ngcMetadata:
@@ -737,7 +737,7 @@ models:
         value: 9GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__8
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx1 NVFP4 Throughput
       ngcMetadata:
@@ -773,7 +773,7 @@ models:
         value: 30GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__9
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx1 FP8 Latency
       ngcMetadata:
@@ -809,7 +809,7 @@ models:
         value: 30GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__10
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct H200_NVLx2 BF16 Latency
       ngcMetadata:
@@ -845,7 +845,7 @@ models:
         value: 30GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__11
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct A100_SXM4_40GBx2 BF16 Latency
       ngcMetadata:
@@ -917,7 +917,7 @@ models:
         value: 16GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__12
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct H200_NVLx2 FP8 Latency
       ngcMetadata:
@@ -1025,7 +1025,7 @@ models:
         value: 16GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__13
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct GH200_144GBx1 BF16 Throughput
       ngcMetadata:
@@ -1097,7 +1097,7 @@ models:
         value: 9GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__14
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx1 NVFP4 Latency
       ngcMetadata:
@@ -1133,7 +1133,7 @@ models:
         value: 30GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__15
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct H200_NVLx1 FP8 Throughput
       ngcMetadata:
@@ -1349,7 +1349,7 @@ models:
         value: 6GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__16
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct H100_NVLx2 BF16 Latency
       ngcMetadata:
@@ -1385,7 +1385,7 @@ models:
         value: 30GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__17
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct GH200_144GBx1 FP8 Throughput
       ngcMetadata:
@@ -1457,7 +1457,7 @@ models:
         value: 16GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__18
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct GH200_480GBx1 BF16 Latency
       ngcMetadata:
@@ -1529,7 +1529,7 @@ models:
         value: 9GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__19
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct RTX6000_ADAx1 INT4_AWQ Latency
       ngcMetadata:
@@ -1565,7 +1565,7 @@ models:
         value: 30GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__20
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx1 BF16 Latency
       ngcMetadata:
@@ -1601,7 +1601,7 @@ models:
         value: 30GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__21
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx1 BF16 Throughput
       ngcMetadata:
@@ -1673,7 +1673,7 @@ models:
         value: 16GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__22
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct GH200_144GBx1 BF16 Latency
       ngcMetadata:
@@ -1745,7 +1745,7 @@ models:
         value: 9GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__23
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct H100_NVLx1 BF16 Throughput
       ngcMetadata:
@@ -1781,7 +1781,7 @@ models:
         value: 30GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__24
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct GH200_480GBx1 FP8 Throughput
       ngcMetadata:
@@ -1817,7 +1817,7 @@ models:
         value: 30GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__25
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx1 FP8 Throughput
       ngcMetadata:
@@ -1889,7 +1889,7 @@ models:
         value: 16GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16
+    - profileId: nim/meta/llama-3.1-8b-instruct:8c22764a7e3675c50d4c7c9a4edb474456022b16__26
       framework: TensorRT-LLM
       displayName: Llama 3.1 8B Instruct GH200_144GBx1 FP8 Latency
       ngcMetadata:
@@ -2074,7 +2074,7 @@ models:
         value: 139GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__2
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct A100_SXM4_40GBx8 BF16 Throughput
       ngcMetadata:
@@ -2182,7 +2182,7 @@ models:
         value: 41GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__3
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx2 FP8 Throughput
       ngcMetadata:
@@ -2218,7 +2218,7 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__4
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct H100_NVLx2 BF16 Throughput
       ngcMetadata:
@@ -2326,7 +2326,7 @@ models:
         value: 69GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__5
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct H100_NVLx2 FP8 Throughput
       ngcMetadata:
@@ -2398,7 +2398,7 @@ models:
         value: 134GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__6
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx2 NVFP4 Throughput
       ngcMetadata:
@@ -2506,7 +2506,7 @@ models:
         value: 69GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__7
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct GH200_144GBx2 BF16 Latency
       ngcMetadata:
@@ -2542,7 +2542,7 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__8
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct H200_NVLx2 FP8 Latency
       ngcMetadata:
@@ -2578,7 +2578,7 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__9
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct GH200_144GBx1 FP8 Throughput
       ngcMetadata:
@@ -2758,7 +2758,7 @@ models:
         value: 68GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__10
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct GH200_480GBx1 FP8 Throughput
       ngcMetadata:
@@ -2794,7 +2794,7 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__11
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx4 BF16 Throughput
       ngcMetadata:
@@ -2866,7 +2866,7 @@ models:
         value: 147GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__12
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct GH200_480GBx1 FP8 Latency
       ngcMetadata:
@@ -2974,7 +2974,7 @@ models:
         value: 69GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__13
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct H200_NVLx1 FP8 Throughput
       ngcMetadata:
@@ -3082,7 +3082,7 @@ models:
         value: 69GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__14
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct H100_NVLx4 FP8 Latency
       ngcMetadata:
@@ -3118,7 +3118,7 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__15
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct GH200_144GBx2 BF16 Throughput
       ngcMetadata:
@@ -3190,7 +3190,7 @@ models:
         value: 150GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__16
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct GH200_144GBx2 FP8 Latency
       ngcMetadata:
@@ -3262,7 +3262,7 @@ models:
         value: 68GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__17
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct GH200_144GBx2 FP8 Throughput
       ngcMetadata:
@@ -3298,7 +3298,7 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__18
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct A100_SXM4_40GBx8 BF16 Latency
       ngcMetadata:
@@ -3406,7 +3406,7 @@ models:
         value: 138GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__19
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct H100_NVLx4 BF16 Latency
       ngcMetadata:
@@ -3550,7 +3550,7 @@ models:
         value: 150GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__20
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx4 NVFP4 Latency
       ngcMetadata:
@@ -3622,7 +3622,7 @@ models:
         value: 134GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__21
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx4 FP8 Latency
       ngcMetadata:
@@ -3658,7 +3658,7 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd
+    - profileId: nim/meta/llama-3.1-70b-instruct:1d54af340dc8906a2d21146191a9c184c35e47bd__22
       framework: TensorRT-LLM
       displayName: Llama 3.1 70B Instruct H200_NVLx2 BF16 Throughput
       ngcMetadata:

--- a/models/private/1.51.0-h2100/llama-3.1-nemotron-nano-v1.yaml
+++ b/models/private/1.51.0-h2100/llama-3.1-nemotron-nano-v1.yaml
@@ -227,7 +227,7 @@ models:
         value: 6GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama3.1-nemotron-nano-4b-v1.1:hf-9f834a8-fix-checksum
+    - profileId: nim/nvidia/llama3.1-nemotron-nano-4b-v1.1:hf-9f834a8-fix-checksum__2
       framework: TensorRT-LLM
       displayName: Llama 3.1 Nemotron Nano 4B V1.1 A100_SXM4_40GBx1 BF16 Throughput
       ngcMetadata:
@@ -297,7 +297,7 @@ models:
         value: 9GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama3.1-nemotron-nano-4b-v1.1:hf-9f834a8-fix-checksum
+    - profileId: nim/nvidia/llama3.1-nemotron-nano-4b-v1.1:hf-9f834a8-fix-checksum__3
       framework: TensorRT-LLM
       displayName: Llama 3.1 Nemotron Nano 4B V1.1 GH200_480GBx1 BF16 Throughput
       ngcMetadata:
@@ -332,7 +332,7 @@ models:
         value: 9GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama3.1-nemotron-nano-4b-v1.1:hf-9f834a8-fix-checksum
+    - profileId: nim/nvidia/llama3.1-nemotron-nano-4b-v1.1:hf-9f834a8-fix-checksum__4
       framework: TensorRT-LLM
       displayName: Llama 3.1 Nemotron Nano 4B V1.1 Generic NVIDIA GPUx2 BF16
       ngcMetadata:
@@ -360,7 +360,7 @@ models:
         value: TENSORRT_LLM
       - key: TRTLLM BUILDABLE
         value: 'TRUE'
-    - profileId: nim/nvidia/llama3.1-nemotron-nano-4b-v1.1:hf-9f834a8-fix-checksum
+    - profileId: nim/nvidia/llama3.1-nemotron-nano-4b-v1.1:hf-9f834a8-fix-checksum__5
       framework: TensorRT-LLM
       displayName: Llama 3.1 Nemotron Nano 4B V1.1 Generic NVIDIA GPUx1 BF16
       ngcMetadata:
@@ -525,7 +525,7 @@ models:
         value: 1.8.4
       - key: DOWNLOAD SIZE
         value: 16GB
-    - profileId: nim/nvidia/llama-3.1-nemotron-nano-8b-v1:hf-25.03.17-0508-tool-use-v2
+    - profileId: nim/nvidia/llama-3.1-nemotron-nano-8b-v1:hf-25.03.17-0508-tool-use-v2__2
       framework: TensorRT-LLM
       displayName: Llama 3.1 Nemotron Nano 8B V1 H100_NVLx1 FP8 Throughput
       ngcMetadata:
@@ -756,7 +756,7 @@ models:
         value: 1.8.4
       - key: DOWNLOAD SIZE
         value: 17GB
-    - profileId: nim/nvidia/llama-3.1-nemotron-nano-8b-v1:hf-25.03.17-0508-tool-use-v2
+    - profileId: nim/nvidia/llama-3.1-nemotron-nano-8b-v1:hf-25.03.17-0508-tool-use-v2__3
       framework: TensorRT-LLM
       displayName: Llama 3.1 Nemotron Nano 8B V1 H100_NVLx2 FP8 Latency
       ngcMetadata:
@@ -921,7 +921,7 @@ models:
         value: 1.8.4
       - key: DOWNLOAD SIZE
         value: 17GB
-    - profileId: nim/nvidia/llama-3.1-nemotron-nano-8b-v1:hf-25.03.17-0508-tool-use-v2
+    - profileId: nim/nvidia/llama-3.1-nemotron-nano-8b-v1:hf-25.03.17-0508-tool-use-v2__4
       framework: TensorRT-LLM
       displayName: Llama 3.1 Nemotron Nano 8B V1 H100_NVLx2 BF16 Latency
       ngcMetadata:
@@ -1086,7 +1086,7 @@ models:
         value: 1.8.4
       - key: DOWNLOAD SIZE
         value: 17GB
-    - profileId: nim/nvidia/llama-3.1-nemotron-nano-8b-v1:hf-25.03.17-0508-tool-use-v2
+    - profileId: nim/nvidia/llama-3.1-nemotron-nano-8b-v1:hf-25.03.17-0508-tool-use-v2__5
       framework: TensorRT-LLM
       displayName: Llama 3.1 Nemotron Nano 8B V1 Generic NVIDIA GPUx2 BF16
       ngcMetadata:
@@ -1110,7 +1110,7 @@ models:
         value: 1.8.4
       - key: DOWNLOAD SIZE
         value: 15GB
-    - profileId: nim/nvidia/llama-3.1-nemotron-nano-8b-v1:hf-25.03.17-0508-tool-use-v2
+    - profileId: nim/nvidia/llama-3.1-nemotron-nano-8b-v1:hf-25.03.17-0508-tool-use-v2__6
       framework: TensorRT-LLM
       displayName: Llama 3.1 Nemotron Nano 8B V1 Generic NVIDIA GPUx4 BF16
       ngcMetadata:
@@ -1134,7 +1134,7 @@ models:
         value: 1.8.4
       - key: DOWNLOAD SIZE
         value: 15GB
-    - profileId: nim/nvidia/llama-3.1-nemotron-nano-8b-v1:hf-25.03.17-0508-tool-use-v2
+    - profileId: nim/nvidia/llama-3.1-nemotron-nano-8b-v1:hf-25.03.17-0508-tool-use-v2__7
       framework: TensorRT-LLM
       displayName: Llama 3.1 Nemotron Nano 8B V1 Generic NVIDIA GPUx1 BF16
       ngcMetadata:

--- a/models/private/1.51.0-h2100/llama-3.2-instruct.yaml
+++ b/models/private/1.51.0-h2100/llama-3.2-instruct.yaml
@@ -197,7 +197,7 @@ models:
         value: 5GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__2
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct H100_NVLx1 BF16 Throughput
       ngcMetadata:
@@ -233,7 +233,7 @@ models:
         value: 5GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__3
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct GH200_144GBx1 FP8 Latency
       ngcMetadata:
@@ -305,7 +305,7 @@ models:
         value: 3GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__4
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct RTX6000_BLACKWELL_SVx1 FP8 Latency
       ngcMetadata:
@@ -341,7 +341,7 @@ models:
         value: 5GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__5
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct RTX6000_BLACKWELL_SVx1 BF16 Throughput
       ngcMetadata:
@@ -377,7 +377,7 @@ models:
         value: 5GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__6
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct H200_NVLx1 FP8 Throughput
       ngcMetadata:
@@ -413,7 +413,7 @@ models:
         value: 5GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__7
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct H200_NVLx1 BF16 Throughput
       ngcMetadata:
@@ -449,7 +449,7 @@ models:
         value: 5GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__8
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct H100_NVLx1 FP8 Throughput
       ngcMetadata:
@@ -485,7 +485,7 @@ models:
         value: 5GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__9
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct H200_NVLx2 FP8 Latency
       ngcMetadata:
@@ -593,7 +593,7 @@ models:
         value: 4GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__10
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct A100_SXM4_40GBx2 BF16 Latency
       ngcMetadata:
@@ -629,7 +629,7 @@ models:
         value: 5GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__11
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct GH200_144GBx1 BF16 Latency
       ngcMetadata:
@@ -665,7 +665,7 @@ models:
         value: 5GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__12
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct A100_SXM4_40GBx1 BF16 Throughput
       ngcMetadata:
@@ -881,7 +881,7 @@ models:
         value: 2GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__13
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct GH200_480GBx1 FP8 Throughput
       ngcMetadata:
@@ -917,7 +917,7 @@ models:
         value: 5GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__14
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct H200_NVLx2 BF16 Latency
       ngcMetadata:
@@ -989,7 +989,7 @@ models:
         value: 4GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__15
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct RTX6000_BLACKWELL_SVx1 FP8 Throughput
       ngcMetadata:
@@ -1133,7 +1133,7 @@ models:
         value: 4GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__16
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct GH200_480GBx1 BF16 Throughput
       ngcMetadata:
@@ -1313,7 +1313,7 @@ models:
         value: 4GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__17
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct GH200_144GBx1 FP8 Throughput
       ngcMetadata:
@@ -1385,7 +1385,7 @@ models:
         value: 4GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__18
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct H100_NVLx2 FP8 Latency
       ngcMetadata:
@@ -1457,7 +1457,7 @@ models:
         value: 2GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__19
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct GH200_144GBx1 BF16 Throughput
       ngcMetadata:
@@ -1601,7 +1601,7 @@ models:
         value: 3GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling
+    - profileId: nim/meta/llama-3.2-1b-instruct:hf-9213176-tool_calling__20
       framework: TensorRT-LLM
       displayName: Llama 3.2 1B Instruct H100_NVLx2 BF16 Latency
       ngcMetadata:
@@ -1817,7 +1817,7 @@ models:
         value: 12GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2
+    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2__2
       framework: TensorRT-LLM
       displayName: Llama 3.2 3B Instruct A100_SXM4_40GBx2 BF16 Latency
       ngcMetadata:
@@ -1992,7 +1992,7 @@ models:
         value: 5GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2
+    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2__3
       framework: TensorRT-LLM
       displayName: Llama 3.2 3B Instruct RTX6000_ADAx1 BF16 Latency
       ngcMetadata:
@@ -2027,7 +2027,7 @@ models:
         value: 12GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2
+    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2__4
       framework: TensorRT-LLM
       displayName: Llama 3.2 3B Instruct H100_NVLx1 FP8 Throughput
       ngcMetadata:
@@ -2237,7 +2237,7 @@ models:
         value: 5GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2
+    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2__5
       framework: TensorRT-LLM
       displayName: Llama 3.2 3B Instruct RTX6000_ADAx1 FP8 Throughput
       ngcMetadata:
@@ -2377,7 +2377,7 @@ models:
         value: 7GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2
+    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2__6
       framework: TensorRT-LLM
       displayName: Llama 3.2 3B Instruct H100_NVLx2 FP8 Latency
       ngcMetadata:
@@ -2412,7 +2412,7 @@ models:
         value: 12GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2
+    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2__7
       framework: TensorRT-LLM
       displayName: Llama 3.2 3B Instruct RTX6000_ADAx1 FP8 Latency
       ngcMetadata:
@@ -2482,7 +2482,7 @@ models:
         value: 7GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2
+    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2__8
       framework: TensorRT-LLM
       displayName: Llama 3.2 3B Instruct RTX6000_ADAx1 BF16 Throughput
       ngcMetadata:
@@ -2657,7 +2657,7 @@ models:
         value: 8GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2
+    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2__9
       framework: TensorRT-LLM
       displayName: Llama 3.2 3B Instruct H100_NVLx2 BF16 Latency
       ngcMetadata:
@@ -2797,7 +2797,7 @@ models:
         value: 5GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2
+    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2__10
       framework: TensorRT-LLM
       displayName: Llama 3.2 3B Instruct A100_SXM4_40GBx1 BF16 Throughput
       ngcMetadata:
@@ -3042,7 +3042,7 @@ models:
         value: 8GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2
+    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2__11
       framework: TensorRT-LLM
       displayName: Llama 3.2 3B Instruct GH200_480GBx1 FP8 Throughput
       ngcMetadata:
@@ -3112,7 +3112,7 @@ models:
         value: 7GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2
+    - profileId: nim/meta/llama-3.2-3b-instruct:hf-392a143-tool-use-v2__12
       framework: TensorRT-LLM
       displayName: Llama 3.2 3B Instruct GH200_480GBx1 BF16 Throughput
       ngcMetadata:

--- a/models/private/1.51.0-h2100/llama-3.2-nv-rerankqa-v2.yaml
+++ b/models/private/1.51.0-h2100/llama-3.2-nv-rerankqa-v2.yaml
@@ -110,7 +110,7 @@ models:
         value: TENSORRT
       - key: MODEL TYPE
         value: TENSORRT
-    - profileId: nim/nvidia/llama-3.2-nv-rerankqa-1b-v2:a100x1-trt-fp16-dxtbz8wstg
+    - profileId: nim/nvidia/llama-3.2-nv-rerankqa-1b-v2:a100x1-trt-fp16-dxtbz8wstg__2
       framework: TensorRT-LLM
       displayName: Llama 3.2 NV Rerankqa 1B V2 NVIDIA A100-SXM4-80GBx1 FP16
       ngcMetadata:
@@ -327,7 +327,7 @@ models:
         value: TENSORRT
       - key: MODEL TYPE
         value: TENSORRT
-    - profileId: nim/nvidia/llama-3.2-nv-rerankqa-1b-v2:h100x1-trt-fp8-bm87q6egvq
+    - profileId: nim/nvidia/llama-3.2-nv-rerankqa-1b-v2:h100x1-trt-fp8-bm87q6egvq__2
       framework: TensorRT-LLM
       displayName: Llama 3.2 NV Rerankqa 1B V2 NVIDIA H100 NVLx1 FP8
       ngcMetadata:
@@ -358,7 +358,7 @@ models:
         value: TENSORRT
       - key: MODEL TYPE
         value: TENSORRT
-    - profileId: nim/nvidia/llama-3.2-nv-rerankqa-1b-v2:h100x1-trt-fp16--ckqlv3j2g
+    - profileId: nim/nvidia/llama-3.2-nv-rerankqa-1b-v2:h100x1-trt-fp16--ckqlv3j2g__2
       framework: TensorRT-LLM
       displayName: Llama 3.2 NV Rerankqa 1B V2 NVIDIA H100 80GB HBM3x1 FP16
       ngcMetadata:

--- a/models/private/1.51.0-h2100/llama-3.3-instruct.yaml
+++ b/models/private/1.51.0-h2100/llama-3.3-instruct.yaml
@@ -269,7 +269,7 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__2
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct A100_SXM4_40GBx8 BF16 Throughput
       ngcMetadata:
@@ -305,7 +305,7 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__3
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct H100_NVLx2 BF16 Throughput
       ngcMetadata:
@@ -377,7 +377,7 @@ models:
         value: 69GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__4
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct GH200_144GBx2 BF16 Throughput
       ngcMetadata:
@@ -485,7 +485,7 @@ models:
         value: 147GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__5
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct GH200_144GBx2 FP8 Latency
       ngcMetadata:
@@ -521,7 +521,7 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__6
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct GH200_144GBx2 FP8 Throughput
       ngcMetadata:
@@ -629,7 +629,7 @@ models:
         value: 69GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__7
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct GH200_144GBx1 FP8 Throughput
       ngcMetadata:
@@ -665,7 +665,7 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__8
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct GH200_480GBx1 FP8 Latency
       ngcMetadata:
@@ -773,7 +773,7 @@ models:
         value: 134GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__9
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx8 BF16 Latency
       ngcMetadata:
@@ -953,7 +953,7 @@ models:
         value: 69GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__10
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct A100_SXM4_40GBx8 BF16 Latency
       ngcMetadata:
@@ -989,7 +989,7 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__11
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct H200_NVLx1 FP8 Throughput
       ngcMetadata:
@@ -1169,7 +1169,7 @@ models:
         value: 69GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__12
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx4 BF16 Throughput
       ngcMetadata:
@@ -1241,7 +1241,7 @@ models:
         value: 68GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__13
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct GH200_144GBx2 BF16 Latency
       ngcMetadata:
@@ -1277,7 +1277,7 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__14
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx2 FP8 Throughput
       ngcMetadata:
@@ -1349,7 +1349,7 @@ models:
         value: 68GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__15
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct GH200_480GBx1 FP8 Throughput
       ngcMetadata:
@@ -1421,7 +1421,7 @@ models:
         value: 69GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__16
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct H200_NVLx2 FP8 Latency
       ngcMetadata:
@@ -1457,7 +1457,7 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__17
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx2 NVFP4 Throughput
       ngcMetadata:
@@ -1565,7 +1565,7 @@ models:
         value: 134GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__18
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct H100_NVLx2 FP8 Throughput
       ngcMetadata:
@@ -1637,7 +1637,7 @@ models:
         value: 138GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__19
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx4 FP8 Latency
       ngcMetadata:
@@ -1673,7 +1673,7 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__20
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct H100_NVLx4 BF16 Latency
       ngcMetadata:
@@ -1745,7 +1745,7 @@ models:
         value: 68GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__21
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx4 NVFP4 Latency
       ngcMetadata:
@@ -1817,7 +1817,7 @@ models:
         value: 139GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b
+    - profileId: nim/meta/llama-3.3-70b-instruct:6f6073b423013f6a7d4d9f39144961bfbfbc386b__22
       framework: TensorRT-LLM
       displayName: Llama 3.3 70B Instruct H100_NVLx4 FP8 Latency
       ngcMetadata:

--- a/models/private/1.51.0-h2100/llama-3.3-nemotron-super-49b-v1.yaml
+++ b/models/private/1.51.0-h2100/llama-3.3-nemotron-super-49b-v1.yaml
@@ -227,7 +227,7 @@ models:
         value: 49GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1:hf-1a2cb80-nim-0613-tool-use-v2
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1:hf-1a2cb80-nim-0613-tool-use-v2__2
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1 H100_NVLx1 FP8 Throughput
       ngcMetadata:
@@ -297,7 +297,7 @@ models:
         value: 96GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1:hf-1a2cb80-nim-0613-tool-use-v2
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1:hf-1a2cb80-nim-0613-tool-use-v2__3
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1 A100_SXM4_40GBx4 BF16 Throughput
       ngcMetadata:
@@ -437,7 +437,7 @@ models:
         value: 49GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1:hf-1a2cb80-nim-0613-tool-use-v2
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1:hf-1a2cb80-nim-0613-tool-use-v2__4
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1 A100_SXM4_40GBx8 BF16 Latency
       ngcMetadata:
@@ -472,7 +472,7 @@ models:
         value: 93GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1:hf-1a2cb80-nim-0613-tool-use-v2
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1:hf-1a2cb80-nim-0613-tool-use-v2__5
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1 H100_NVLx2 FP8 Latency
       ngcMetadata:
@@ -542,7 +542,7 @@ models:
         value: 93GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1:hf-1a2cb80-nim-0613-tool-use-v2
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1:hf-1a2cb80-nim-0613-tool-use-v2__6
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1 H100_NVLx2 BF16 Throughput
       ngcMetadata:
@@ -752,7 +752,7 @@ models:
         value: 96GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1:hf-1a2cb80-nim-0613-tool-use-v2
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1:hf-1a2cb80-nim-0613-tool-use-v2__7
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1 Generic NVIDIA GPUx8 BF16
       ngcMetadata:
@@ -780,7 +780,7 @@ models:
         value: TENSORRT_LLM
       - key: TRTLLM BUILDABLE
         value: 'TRUE'
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1:hf-1a2cb80-nim-0613-tool-use-v2
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1:hf-1a2cb80-nim-0613-tool-use-v2__8
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1 Generic NVIDIA GPUx2 BF16
       ngcMetadata:
@@ -808,7 +808,7 @@ models:
         value: TENSORRT_LLM
       - key: TRTLLM BUILDABLE
         value: 'TRUE'
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1:hf-1a2cb80-nim-0613-tool-use-v2
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1:hf-1a2cb80-nim-0613-tool-use-v2__9
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1 Generic NVIDIA GPUx4 BF16
       ngcMetadata:
@@ -1165,7 +1165,7 @@ models:
         value: 30GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__2
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 A100_SXM4_40GBx4 BF16 Throughput
       ngcMetadata:
@@ -1201,7 +1201,7 @@ models:
         value: 93GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__3
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx1 FP8 Throughput
       ngcMetadata:
@@ -1237,7 +1237,7 @@ models:
         value: 93GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__4
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 H200_NVLx1 FP8 Throughput
       ngcMetadata:
@@ -1309,7 +1309,7 @@ models:
         value: 94GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__5
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx2 NVFP4 Throughput
       ngcMetadata:
@@ -1381,7 +1381,7 @@ models:
         value: 96GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__6
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 H100_NVLx1 FP8 Throughput
       ngcMetadata:
@@ -1417,7 +1417,7 @@ models:
         value: 93GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__7
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 GH200_144GBx1 BF16 Throughput
       ngcMetadata:
@@ -1453,7 +1453,7 @@ models:
         value: 93GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__8
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx1 NVFP4 Throughput
       ngcMetadata:
@@ -1489,7 +1489,7 @@ models:
         value: 93GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__9
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 H100_NVLx2 BF16 Throughput
       ngcMetadata:
@@ -1633,7 +1633,7 @@ models:
         value: 100GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__10
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx2 NVFP4 Latency
       ngcMetadata:
@@ -1669,7 +1669,7 @@ models:
         value: 93GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__11
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 H100_NVLx2 FP8 Latency
       ngcMetadata:
@@ -1741,7 +1741,7 @@ models:
         value: 94GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__12
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx2 FP8 Latency
       ngcMetadata:
@@ -1777,7 +1777,7 @@ models:
         value: 93GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__13
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 GH200_480GBx1 FP8 Throughput
       ngcMetadata:
@@ -1957,7 +1957,7 @@ models:
         value: 100GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__14
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 H200_NVLx2 BF16 Latency
       ngcMetadata:
@@ -2065,7 +2065,7 @@ models:
         value: 49GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__15
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 H200_NVLx2 FP8 Latency
       ngcMetadata:
@@ -2137,7 +2137,7 @@ models:
         value: 49GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__16
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 H200_NVLx1 BF16 Throughput
       ngcMetadata:
@@ -2209,7 +2209,7 @@ models:
         value: 49GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__17
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 GH200_144GBx2 FP8 Latency
       ngcMetadata:
@@ -2245,7 +2245,7 @@ models:
         value: 93GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__18
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 H100_NVLx4 BF16 Latency
       ngcMetadata:
@@ -2281,7 +2281,7 @@ models:
         value: 93GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__19
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 A100_SXM4_40GBx8 BF16 Latency
       ngcMetadata:
@@ -2317,7 +2317,7 @@ models:
         value: 93GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__20
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx2 BF16 Throughput
       ngcMetadata:
@@ -2425,7 +2425,7 @@ models:
         value: 49GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__21
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 GH200_144GBx2 BF16 Latency
       ngcMetadata:
@@ -2569,7 +2569,7 @@ models:
         value: 49GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-f091ea1-fix-chat-template-jet__22
       framework: TensorRT-LLM
       displayName: Llama 3.3 Nemotron Super 49B V1.5 GH200_144GBx1 FP8 Throughput
       ngcMetadata:

--- a/models/private/1.51.0-h2100/mistral-instruct.yaml
+++ b/models/private/1.51.0-h2100/mistral-instruct.yaml
@@ -120,7 +120,7 @@ models:
         value: 8GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__2
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 H200_NVLx2 BF16 Latency
       ngcMetadata:
@@ -192,7 +192,7 @@ models:
         value: 8GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__3
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 RTX6000_BLACKWELL_SVx1 BF16 Latency
       ngcMetadata:
@@ -264,7 +264,7 @@ models:
         value: 14GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__4
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 A100_SXM4_40GBx2 BF16 Latency
       ngcMetadata:
@@ -336,7 +336,7 @@ models:
         value: 14GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__5
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 GH200_144GBx1 BF16 Throughput
       ngcMetadata:
@@ -372,7 +372,7 @@ models:
         value: 28GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__6
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 GH200_144GBx1 BF16 Latency
       ngcMetadata:
@@ -408,7 +408,7 @@ models:
         value: 28GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__7
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 GH200_144GBx1 FP8 Throughput
       ngcMetadata:
@@ -516,7 +516,7 @@ models:
         value: 14GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__8
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 H100_NVLx1 FP8 Throughput
       ngcMetadata:
@@ -588,7 +588,7 @@ models:
         value: 14GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__9
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 H100_NVLx2 FP8 Latency
       ngcMetadata:
@@ -696,7 +696,7 @@ models:
         value: 8GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__10
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 GH200_144GBx1 FP8 Latency
       ngcMetadata:
@@ -732,7 +732,7 @@ models:
         value: 28GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__11
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 GH200_480GBx1 BF16 Latency
       ngcMetadata:
@@ -768,7 +768,7 @@ models:
         value: 28GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__12
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 RTX6000_BLACKWELL_SVx1 FP8 Throughput
       ngcMetadata:
@@ -876,7 +876,7 @@ models:
         value: 14GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__13
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 H200_NVLx1 FP8 Throughput
       ngcMetadata:
@@ -912,7 +912,7 @@ models:
         value: 28GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__14
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 H100_NVLx1 BF16 Throughput
       ngcMetadata:
@@ -948,7 +948,7 @@ models:
         value: 28GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__15
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 GH200_480GBx1 BF16 Throughput
       ngcMetadata:
@@ -1128,7 +1128,7 @@ models:
         value: 14GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__16
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 A100_SXM4_40GBx1 BF16 Throughput
       ngcMetadata:
@@ -1164,7 +1164,7 @@ models:
         value: 28GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__17
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 GH200_480GBx1 FP8 Latency
       ngcMetadata:
@@ -1200,7 +1200,7 @@ models:
         value: 28GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__18
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 RTX6000_BLACKWELL_SVx1 FP8 Latency
       ngcMetadata:
@@ -1380,7 +1380,7 @@ models:
         value: 8GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__19
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 GH200_480GBx1 FP8 Throughput
       ngcMetadata:
@@ -1416,7 +1416,7 @@ models:
         value: 28GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__20
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 RTX6000_BLACKWELL_SVx1 BF16 Throughput
       ngcMetadata:
@@ -1452,7 +1452,7 @@ models:
         value: 28GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__21
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 H200_NVLx2 FP8 Latency
       ngcMetadata:
@@ -1596,7 +1596,7 @@ models:
         value: 8GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16
+    - profileId: nim/mistralai/mistral-7b-instruct-v0-3:hf-0d4b76e-tool_calling-bf16__22
       framework: TensorRT-LLM
       displayName: Mistral 7B Instruct V0.3 H100_NVLx2 BF16 Latency
       ngcMetadata:

--- a/models/private/1.51.0-h2100/mixtral-instruct.yaml
+++ b/models/private/1.51.0-h2100/mixtral-instruct.yaml
@@ -222,7 +222,7 @@ models:
         value: 44GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mixtral-8x7b-instruct-v01:hf-a60832c-0508-tool-use-v2
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v01:hf-a60832c-0508-tool-use-v2__2
       framework: TensorRT-LLM
       displayName: Mixtral 8x7b Instruct V0.1 H100_NVLx1 FP8 Throughput
       ngcMetadata:
@@ -292,7 +292,7 @@ models:
         value: 88GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mixtral-8x7b-instruct-v01:hf-a60832c-0508-tool-use-v2
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v01:hf-a60832c-0508-tool-use-v2__3
       framework: TensorRT-LLM
       displayName: Mixtral 8x7b Instruct V0.1 A100_SXM4_40GBx4 BF16 Throughput
       ngcMetadata:
@@ -467,7 +467,7 @@ models:
         value: 88GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mixtral-8x7b-instruct-v01:hf-a60832c-0508-tool-use-v2
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v01:hf-a60832c-0508-tool-use-v2__4
       framework: TensorRT-LLM
       displayName: Mixtral 8x7b Instruct V0.1 A100_SXM4_40GBx8 BF16 Latency
       ngcMetadata:
@@ -572,7 +572,7 @@ models:
         value: 90GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mixtral-8x7b-instruct-v01:hf-a60832c-0508-tool-use-v2
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v01:hf-a60832c-0508-tool-use-v2__5
       framework: TensorRT-LLM
       displayName: Mixtral 8x7b Instruct V0.1 H100_NVLx2 FP8 Latency
       ngcMetadata:
@@ -677,7 +677,7 @@ models:
         value: 88GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mixtral-8x7b-instruct-v01:hf-a60832c-0508-tool-use-v2
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v01:hf-a60832c-0508-tool-use-v2__6
       framework: TensorRT-LLM
       displayName: Mixtral 8x7b Instruct V0.1 H100_NVLx2 BF16 Throughput
       ngcMetadata:
@@ -887,7 +887,7 @@ models:
         value: 88GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
-    - profileId: nim/mistralai/mixtral-8x7b-instruct-v01:hf-a60832c-0508-tool-use-v2
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v01:hf-a60832c-0508-tool-use-v2__7
       framework: TensorRT-LLM
       displayName: Mixtral 8x7b Instruct V0.1 Generic NVIDIA GPUx8 BF16
       ngcMetadata:
@@ -915,7 +915,7 @@ models:
         value: TENSORRT_LLM
       - key: TRTLLM BUILDABLE
         value: 'TRUE'
-    - profileId: nim/mistralai/mixtral-8x7b-instruct-v01:hf-a60832c-0508-tool-use-v2
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v01:hf-a60832c-0508-tool-use-v2__8
       framework: TensorRT-LLM
       displayName: Mixtral 8x7b Instruct V0.1 Generic NVIDIA GPUx2 BF16
       ngcMetadata:
@@ -943,7 +943,7 @@ models:
         value: TENSORRT_LLM
       - key: TRTLLM BUILDABLE
         value: 'TRUE'
-    - profileId: nim/mistralai/mixtral-8x7b-instruct-v01:hf-a60832c-0508-tool-use-v2
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v01:hf-a60832c-0508-tool-use-v2__9
       framework: TensorRT-LLM
       displayName: Mixtral 8x7b Instruct V0.1 Generic NVIDIA GPUx4 BF16
       ngcMetadata:

--- a/models/private/1.51.0-h2100/paddleocr.yaml
+++ b/models/private/1.51.0-h2100/paddleocr.yaml
@@ -79,7 +79,7 @@ models:
         value: TRITON
       - key: MODEL TYPE
         value: TENSORRT
-    - profileId: nim/baidu/paddleocr:2_TRT_python_2
+    - profileId: nim/baidu/paddleocr:2_TRT_python_2__2
       framework: TensorRT-LLM
       displayName: Paddleocr NVIDIA H100 NVLx1 FP16
       ngcMetadata:
@@ -141,7 +141,7 @@ models:
         value: TRITON
       - key: MODEL TYPE
         value: TENSORRT
-    - profileId: nim/baidu/paddleocr:2_TRT_python_2
+    - profileId: nim/baidu/paddleocr:2_TRT_python_2__3
       framework: TensorRT-LLM
       displayName: Paddleocr NVIDIA A100-SXM4-40GBx1 FP16
       ngcMetadata:
@@ -234,7 +234,7 @@ models:
         value: TRITON
       - key: MODEL TYPE
         value: TENSORRT
-    - profileId: nim/baidu/paddleocr:2_TRT_python_2
+    - profileId: nim/baidu/paddleocr:2_TRT_python_2__4
       framework: TensorRT-LLM
       displayName: Paddleocr NVIDIA H100 80GB HBM3x1 FP16
       ngcMetadata:

--- a/models/private/1.51.0-h2100/starcoder-2.yaml
+++ b/models/private/1.51.0-h2100/starcoder-2.yaml
@@ -259,7 +259,7 @@ models:
         value: TENSORRT_LLM
       - key: TRTLLM BUILDABLE
         value: 'TRUE'
-    - profileId: nim/bigcode/starcoder2-7b:hf-bb9afde
+    - profileId: nim/bigcode/starcoder2-7b:hf-bb9afde__2
       framework: TensorRT-LLM
       displayName: Starcoder2 7B Generic NVIDIA GPUx2
       ngcMetadata:

--- a/models/private/1.56.0-h3000/parakeet-1-1b-ctc-en-us.yaml
+++ b/models/private/1.56.0-h3000/parakeet-1-1b-ctc-en-us.yaml
@@ -137,7 +137,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-25.12.4-fp16-ikylnwwcjg
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-25.12.4-fp16-ikylnwwcjg__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline A100x1 Ofl Default
       ngcMetadata:
@@ -286,7 +286,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-25.12.4-fp8-ldxrqwxnow
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-25.12.4-fp8-ldxrqwxnow__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline H100x1 All Default
       ngcMetadata:
@@ -316,7 +316,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-silero-sortformer-25.12.4-fp16-irxmvxkjzq
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-silero-sortformer-25.12.4-fp16-irxmvxkjzq__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline A100x1 Ofl Silero Sortformer
       ngcMetadata:
@@ -376,7 +376,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-silero-sortformer-25.12.4-fp8-r1t-vaoajq
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-silero-sortformer-25.12.4-fp8-r1t-vaoajq__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline H100x1 Ofl Silero Sortformer
       ngcMetadata:
@@ -406,7 +406,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:dgx-sparkx1-ofl-25.12.4-fp16-vt0bruwfdg-dgx_spark
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:dgx-sparkx1-ofl-25.12.4-fp16-vt0bruwfdg-dgx_spark__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline DGX_SPARKx1 All Default
       ngcMetadata:
@@ -525,7 +525,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-25.12.4-fp8-nh6vnluohw
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-25.12.4-fp8-nh6vnluohw__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline L40Sx1 All Default
       ngcMetadata:
@@ -555,7 +555,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-silero-sortformer-25.12.4-fp8-18k-jihwrw
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-silero-sortformer-25.12.4-fp8-18k-jihwrw__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline L40Sx1 Ofl Silero Sortformer
       ngcMetadata:
@@ -585,7 +585,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:dgx-sparkx1-ofl-silero-sortformer-25.12.4-fp16-by3cdocosw-dgx_spark
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:dgx-sparkx1-ofl-silero-sortformer-25.12.4-fp16-by3cdocosw-dgx_spark__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline DGX_SPARKx1 Ofl Silero Sortformer
       ngcMetadata:
@@ -661,7 +661,7 @@ models:
         value: 3GB
       - key: MODEL TYPE
         value: RMIR
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:ofl-rmir-25.12.4
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:ofl-rmir-25.12.4__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline Generic NVIDIA GPUx1
       ngcMetadata:
@@ -707,7 +707,7 @@ models:
         value: 4GB
       - key: MODEL TYPE
         value: RMIR
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:ofl-silero-sortformer-rmir-25.12.4
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:ofl-silero-sortformer-rmir-25.12.4__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline Generic NVIDIA GPUx1
       ngcMetadata:

--- a/models/private/1.56.0/parakeet-1-1b-ctc-en-us.yaml
+++ b/models/private/1.56.0/parakeet-1-1b-ctc-en-us.yaml
@@ -137,7 +137,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-25.12.4-fp16-ikylnwwcjg
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-25.12.4-fp16-ikylnwwcjg__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline A100x1 Ofl Default
       ngcMetadata:
@@ -286,7 +286,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-25.12.4-fp8-ldxrqwxnow
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-25.12.4-fp8-ldxrqwxnow__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline H100x1 All Default
       ngcMetadata:
@@ -316,7 +316,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-silero-sortformer-25.12.4-fp16-irxmvxkjzq
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-silero-sortformer-25.12.4-fp16-irxmvxkjzq__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline A100x1 Ofl Silero Sortformer
       ngcMetadata:
@@ -376,7 +376,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-silero-sortformer-25.12.4-fp8-r1t-vaoajq
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-silero-sortformer-25.12.4-fp8-r1t-vaoajq__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline H100x1 Ofl Silero Sortformer
       ngcMetadata:
@@ -406,7 +406,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:dgx-sparkx1-ofl-25.12.4-fp16-vt0bruwfdg-dgx_spark
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:dgx-sparkx1-ofl-25.12.4-fp16-vt0bruwfdg-dgx_spark__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline DGX_SPARKx1 All Default
       ngcMetadata:
@@ -525,7 +525,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-25.12.4-fp8-nh6vnluohw
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-25.12.4-fp8-nh6vnluohw__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline L40Sx1 All Default
       ngcMetadata:
@@ -555,7 +555,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-silero-sortformer-25.12.4-fp8-18k-jihwrw
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-silero-sortformer-25.12.4-fp8-18k-jihwrw__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline L40Sx1 Ofl Silero Sortformer
       ngcMetadata:
@@ -585,7 +585,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:dgx-sparkx1-ofl-silero-sortformer-25.12.4-fp16-by3cdocosw-dgx_spark
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:dgx-sparkx1-ofl-silero-sortformer-25.12.4-fp16-by3cdocosw-dgx_spark__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline DGX_SPARKx1 Ofl Silero Sortformer
       ngcMetadata:
@@ -661,7 +661,7 @@ models:
         value: 3GB
       - key: MODEL TYPE
         value: RMIR
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:ofl-rmir-25.12.4
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:ofl-rmir-25.12.4__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline Generic NVIDIA GPUx1
       ngcMetadata:
@@ -707,7 +707,7 @@ models:
         value: 4GB
       - key: MODEL TYPE
         value: RMIR
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:ofl-silero-sortformer-rmir-25.12.4
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:ofl-silero-sortformer-rmir-25.12.4__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline Generic NVIDIA GPUx1
       ngcMetadata:

--- a/models/private/1.58.0/parakeet-1-1b-ctc-en-us.yaml
+++ b/models/private/1.58.0/parakeet-1-1b-ctc-en-us.yaml
@@ -137,7 +137,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-25.12.4-fp16-ikylnwwcjg
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-25.12.4-fp16-ikylnwwcjg__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline A100x1 Ofl Default
       ngcMetadata:
@@ -286,7 +286,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-25.12.4-fp8-ldxrqwxnow
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-25.12.4-fp8-ldxrqwxnow__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline H100x1 All Default
       ngcMetadata:
@@ -316,7 +316,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-silero-sortformer-25.12.4-fp16-irxmvxkjzq
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-silero-sortformer-25.12.4-fp16-irxmvxkjzq__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline A100x1 Ofl Silero Sortformer
       ngcMetadata:
@@ -376,7 +376,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-silero-sortformer-25.12.4-fp8-r1t-vaoajq
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-silero-sortformer-25.12.4-fp8-r1t-vaoajq__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline H100x1 Ofl Silero Sortformer
       ngcMetadata:
@@ -406,7 +406,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:dgx-sparkx1-ofl-25.12.4-fp16-vt0bruwfdg-dgx_spark
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:dgx-sparkx1-ofl-25.12.4-fp16-vt0bruwfdg-dgx_spark__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline DGX_SPARKx1 All Default
       ngcMetadata:
@@ -525,7 +525,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-25.12.4-fp8-nh6vnluohw
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-25.12.4-fp8-nh6vnluohw__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline L40Sx1 All Default
       ngcMetadata:
@@ -555,7 +555,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-silero-sortformer-25.12.4-fp8-18k-jihwrw
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-silero-sortformer-25.12.4-fp8-18k-jihwrw__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline L40Sx1 Ofl Silero Sortformer
       ngcMetadata:
@@ -585,7 +585,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:dgx-sparkx1-ofl-silero-sortformer-25.12.4-fp16-by3cdocosw-dgx_spark
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:dgx-sparkx1-ofl-silero-sortformer-25.12.4-fp16-by3cdocosw-dgx_spark__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline DGX_SPARKx1 Ofl Silero Sortformer
       ngcMetadata:
@@ -661,7 +661,7 @@ models:
         value: 3GB
       - key: MODEL TYPE
         value: RMIR
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:ofl-rmir-25.12.4
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:ofl-rmir-25.12.4__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline Generic NVIDIA GPUx1
       ngcMetadata:
@@ -707,7 +707,7 @@ models:
         value: 4GB
       - key: MODEL TYPE
         value: RMIR
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:ofl-silero-sortformer-rmir-25.12.4
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:ofl-silero-sortformer-rmir-25.12.4__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline Generic NVIDIA GPUx1
       ngcMetadata:

--- a/models/private/parakeet-1-1b-ctc-en-us.yaml
+++ b/models/private/parakeet-1-1b-ctc-en-us.yaml
@@ -137,7 +137,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-25.12.4-fp16-ikylnwwcjg
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-25.12.4-fp16-ikylnwwcjg__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline A100x1 Ofl Default
       ngcMetadata:
@@ -286,7 +286,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-25.12.4-fp8-ldxrqwxnow
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-25.12.4-fp8-ldxrqwxnow__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline H100x1 All Default
       ngcMetadata:
@@ -316,7 +316,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-silero-sortformer-25.12.4-fp16-irxmvxkjzq
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-silero-sortformer-25.12.4-fp16-irxmvxkjzq__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline A100x1 Ofl Silero Sortformer
       ngcMetadata:
@@ -376,7 +376,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-silero-sortformer-25.12.4-fp8-r1t-vaoajq
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-silero-sortformer-25.12.4-fp8-r1t-vaoajq__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline H100x1 Ofl Silero Sortformer
       ngcMetadata:
@@ -406,7 +406,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:dgx-sparkx1-ofl-25.12.4-fp16-vt0bruwfdg-dgx_spark
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:dgx-sparkx1-ofl-25.12.4-fp16-vt0bruwfdg-dgx_spark__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline DGX_SPARKx1 All Default
       ngcMetadata:
@@ -525,7 +525,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-25.12.4-fp8-nh6vnluohw
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-25.12.4-fp8-nh6vnluohw__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline L40Sx1 All Default
       ngcMetadata:
@@ -555,7 +555,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-silero-sortformer-25.12.4-fp8-18k-jihwrw
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-silero-sortformer-25.12.4-fp8-18k-jihwrw__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline L40Sx1 Ofl Silero Sortformer
       ngcMetadata:
@@ -585,7 +585,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:dgx-sparkx1-ofl-silero-sortformer-25.12.4-fp16-by3cdocosw-dgx_spark
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:dgx-sparkx1-ofl-silero-sortformer-25.12.4-fp16-by3cdocosw-dgx_spark__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline DGX_SPARKx1 Ofl Silero Sortformer
       ngcMetadata:
@@ -661,7 +661,7 @@ models:
         value: 3GB
       - key: MODEL TYPE
         value: RMIR
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:ofl-rmir-25.12.4
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:ofl-rmir-25.12.4__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline Generic NVIDIA GPUx1
       ngcMetadata:
@@ -707,7 +707,7 @@ models:
         value: 4GB
       - key: MODEL TYPE
         value: RMIR
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:ofl-silero-sortformer-rmir-25.12.4
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:ofl-silero-sortformer-rmir-25.12.4__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline Generic NVIDIA GPUx1
       ngcMetadata:

--- a/models/public/1.55.0-h1000/parakeet-1-1b-ctc-en-us.yaml
+++ b/models/public/1.55.0-h1000/parakeet-1-1b-ctc-en-us.yaml
@@ -137,7 +137,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-25.12.4-fp16-ikylnwwcjg
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-25.12.4-fp16-ikylnwwcjg__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline A100x1 Ofl Default
       ngcMetadata:
@@ -227,7 +227,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-25.12.4-fp8-ldxrqwxnow
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-25.12.4-fp8-ldxrqwxnow__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline H100x1 All Default
       ngcMetadata:
@@ -257,7 +257,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-silero-sortformer-25.12.4-fp16-irxmvxkjzq
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-silero-sortformer-25.12.4-fp16-irxmvxkjzq__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline A100x1 Ofl Silero Sortformer
       ngcMetadata:
@@ -317,7 +317,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-silero-sortformer-25.12.4-fp8-r1t-vaoajq
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-silero-sortformer-25.12.4-fp8-r1t-vaoajq__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline H100x1 Ofl Silero Sortformer
       ngcMetadata:
@@ -407,7 +407,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-25.12.4-fp8-nh6vnluohw
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-25.12.4-fp8-nh6vnluohw__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline L40Sx1 All Default
       ngcMetadata:
@@ -437,7 +437,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-silero-sortformer-25.12.4-fp8-18k-jihwrw
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-silero-sortformer-25.12.4-fp8-18k-jihwrw__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline L40Sx1 Ofl Silero Sortformer
       ngcMetadata:

--- a/models/public/1.58.0/parakeet-1-1b-ctc-en-us.yaml
+++ b/models/public/1.58.0/parakeet-1-1b-ctc-en-us.yaml
@@ -137,7 +137,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-25.12.4-fp16-ikylnwwcjg
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-25.12.4-fp16-ikylnwwcjg__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline A100x1 Ofl Default
       ngcMetadata:
@@ -227,7 +227,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-25.12.4-fp8-ldxrqwxnow
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-25.12.4-fp8-ldxrqwxnow__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline H100x1 All Default
       ngcMetadata:
@@ -257,7 +257,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-silero-sortformer-25.12.4-fp16-irxmvxkjzq
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-silero-sortformer-25.12.4-fp16-irxmvxkjzq__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline A100x1 Ofl Silero Sortformer
       ngcMetadata:
@@ -317,7 +317,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-silero-sortformer-25.12.4-fp8-r1t-vaoajq
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-silero-sortformer-25.12.4-fp8-r1t-vaoajq__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline H100x1 Ofl Silero Sortformer
       ngcMetadata:
@@ -407,7 +407,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-25.12.4-fp8-nh6vnluohw
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-25.12.4-fp8-nh6vnluohw__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline L40Sx1 All Default
       ngcMetadata:
@@ -437,7 +437,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-silero-sortformer-25.12.4-fp8-18k-jihwrw
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-silero-sortformer-25.12.4-fp8-18k-jihwrw__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline L40Sx1 Ofl Silero Sortformer
       ngcMetadata:

--- a/models/public/parakeet-1-1b-ctc-en-us.yaml
+++ b/models/public/parakeet-1-1b-ctc-en-us.yaml
@@ -137,7 +137,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-25.12.4-fp16-ikylnwwcjg
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-25.12.4-fp16-ikylnwwcjg__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline A100x1 Ofl Default
       ngcMetadata:
@@ -227,7 +227,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-25.12.4-fp8-ldxrqwxnow
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-25.12.4-fp8-ldxrqwxnow__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline H100x1 All Default
       ngcMetadata:
@@ -257,7 +257,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-silero-sortformer-25.12.4-fp16-irxmvxkjzq
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:a100x1-ofl-silero-sortformer-25.12.4-fp16-irxmvxkjzq__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline A100x1 Ofl Silero Sortformer
       ngcMetadata:
@@ -317,7 +317,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-silero-sortformer-25.12.4-fp8-r1t-vaoajq
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:h100x1-ofl-silero-sortformer-25.12.4-fp8-r1t-vaoajq__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline H100x1 Ofl Silero Sortformer
       ngcMetadata:
@@ -407,7 +407,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-25.12.4-fp8-nh6vnluohw
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-25.12.4-fp8-nh6vnluohw__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline L40Sx1 All Default
       ngcMetadata:
@@ -437,7 +437,7 @@ models:
         value: 5GB
       - key: MODEL TYPE
         value: PREBUILT
-    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-silero-sortformer-25.12.4-fp8-18k-jihwrw
+    - profileId: nim/nvidia/parakeet-1-1b-ctc-riva:l40sx1-ofl-silero-sortformer-25.12.4-fp8-18k-jihwrw__2
       framework: TensorRT-LLM
       displayName: Parakeet 1 1B Ctc En Us Offline L40Sx1 Ofl Silero Sortformer
       ngcMetadata:

--- a/utils/generate-modelhub-catalog.py
+++ b/utils/generate-modelhub-catalog.py
@@ -748,6 +748,22 @@ def append_optional_spec_fields(spec_list, tags):
         # No special unquoting; just uppercase string representation
         spec_list.append({"key": spec_key, "value": str(raw).upper()})
 
+def append_optimization_profile(optimization_profiles, profile_id_counts, profile_dict):
+    """Append one profile. Duplicate NIM profileId values get suffixes __2, __3, …"""
+    pid = profile_dict.get("profileId")
+    if not isinstance(pid, str) or not str(pid).strip():
+        optimization_profiles.append(profile_dict)
+        return
+    base = str(pid).strip()
+    n = profile_id_counts.get(base, 0) + 1
+    profile_id_counts[base] = n
+    if n == 1:
+        optimization_profiles.append(profile_dict)
+        return
+    final_id = f"{base}__{n}"
+    print(f"Disambiguating profileId: {base} -> {final_id}")
+    optimization_profiles.append({**profile_dict, "profileId": final_id})
+
 def main():
     parser = argparse.ArgumentParser(description="Generate modelhub catalog YAML file using manifest YAML and base model YAML")
     parser.add_argument(
@@ -793,6 +809,7 @@ def main():
     profiles = profile_data.get("profiles", [])
 
     optimization_profiles = []
+    profile_id_counts = {}
     covered_gpu_combinations = set()  # Track which GPU-TP*PP-PRECISION-PROFILE combinations already have profiles
     target_gpus = ["A10G", "L40S", "H100", "H200", "A100"]  # GPUs to generate from generic profiles
 
@@ -848,7 +865,7 @@ def main():
                 metadata_tags = dict(tags)
                 if "gpu" in metadata_tags and isinstance(metadata_tags["gpu"], str):
                     metadata_tags["gpu"] = metadata_tags["gpu"].upper()
-                optimization_profiles.append({
+                append_optimization_profile(optimization_profiles, profile_id_counts, {
                     "profileId": profile_id_uri,
                     "framework": "ONNX",
                     "displayName": display_name,
@@ -998,7 +1015,7 @@ def main():
             "spec": spec_list
         }
 
-        optimization_profiles.append(optimization_profile)
+        append_optimization_profile(optimization_profiles, profile_id_counts, optimization_profile)
         # Track GPU-TP*PP-PRECISION-PROFILE combination as covered
         comb_tp = str(tp_eff)
         comb_pp = str(pp_eff)
@@ -1046,7 +1063,7 @@ def main():
                                 continue
                     vllm_profile = create_gpu_specific_profile_vllm(profile, model, release, target_gpu, args.ngc_api_key)
                     if vllm_profile:
-                        optimization_profiles.append(vllm_profile)
+                        append_optimization_profile(optimization_profiles, profile_id_counts, vllm_profile)
                         covered_gpu_combinations.add(comb)
                         print(f"Generated VLLM profile for {target_gpu} (TP={tp}, PP={pp}, Precision={precision.upper()}, Profile={profile_type.upper()}) from generic profile {profile.get('id', 'unknown')}")
                 continue
@@ -1094,7 +1111,7 @@ def main():
 
                 gpu_profile = create_gpu_specific_profile(profile, model, release, target_gpu, args.ngc_api_key)
                 if gpu_profile:
-                    optimization_profiles.append(gpu_profile)
+                    append_optimization_profile(optimization_profiles, profile_id_counts, gpu_profile)
                     covered_gpu_combinations.add(gpu_combination)
                     print(f"Generated profile for {target_gpu} (TP={tp}, PP={pp}, Precision={precision.upper()}, Profile={profile_type.upper()}) from generic profile {profile.get('id', 'unknown')}")
 
@@ -1129,7 +1146,7 @@ def main():
                             {"key": "DOWNLOAD SIZE", "value": download_size}
                         ])
                         append_optional_spec_fields(spec_list, tags)
-                        optimization_profiles.append({
+                        append_optimization_profile(optimization_profiles, profile_id_counts, {
                             "profileId": profile_id_uri,
                             "framework": "VLLM",
                             "displayName": display_name,
@@ -1186,11 +1203,14 @@ def main():
                 "spec": spec_list
             }
 
-            optimization_profiles.append(optimization_profile)
+            append_optimization_profile(optimization_profiles, profile_id_counts, optimization_profile)
             print(f"Added generic profile {profile.get('id', 'unknown')} without GPU details for private platform")
 
     if optimization_profiles:
-        model_data['models'][0]['modelVariants'][0].setdefault('optimizationProfiles', []).extend(optimization_profiles)
+        variant0 = model_data['models'][0]['modelVariants'][0]
+        if not isinstance(variant0.get('optimizationProfiles'), list):
+            variant0['optimizationProfiles'] = []
+        variant0['optimizationProfiles'].extend(optimization_profiles)
 
     with open(args.output_yaml, 'w') as f:
         yaml.dump(model_data, f)


### PR DESCRIPTION
…Ids for parakeet type of models

When multiple NGC source profiles (for example Riva ASR / Parakeet) resolve to the same NIM profileId string, the catalog could emit duplicate profileId values. append_optimization_profile() now records how many times each base profileId has been emitted; the first occurrence is unchanged, and the 2nd, 3rd, ... occurrences are written with suffixes __2, __3, ... so every optimization block has a distinct profileId. Counting applies across all code paths: ONNX, first-pass TensorRT-LLM, public second-pass VLLM/TRT-LLM generic synthesis, and private generic VLLM/TRT-LLM.

Also normalize optimizationProfiles before extend when the base model template has optimizationProfiles: null, since setdefault does not replace an explicit null.

Hand-edited and regenerated model hub YAMLs (public, private, and CSK trees) are updated to match: parakeet manifests plus duplicate profileId cleanup for other models in private 1.51.0-h2000 and 1.51.0-h2100 where the same NIM or HF id appeared more than once per file.

Downstream: suffixed profileId values are catalog keys; consumers that call NGC with a profileId should use the canonical NIM id (first occurrence) or metadata, not the __N suffixed string, unless the product contract defines otherwise.

Made-with: Cursor