### PR TITLE
DSE-56183: Include profiles related to g7 instances for 05-1

### DIFF
--- a/models/public/1.58.0/cosmos-reason2-8b.yaml
+++ b/models/public/1.58.0/cosmos-reason2-8b.yaml
@@ -534,6 +534,35 @@ models:
         value: 10GB
       - key: LLM ENGINE
         value: VLLM
+    - profileId: nim/nvidia/cosmos-reason2-8b:hf-0303-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Cosmos Reason2 8B RTX6000_BLACKWELL_SVx1 BF16
+      ngcMetadata:
+        438f4f3c69868f7755b07d0a0e03396f2c8862a570e4603572578785b137d1c3:
+          model: nvidia/cosmos-reason2-8b
+          release: '1.7.0'
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            nim_workspace_hash_v1: e905c7b3c8f807e05968ea232cda81e59f27545f1a24e07edad14d003935ee13
+            precision: bf16
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: '1.7.0'
+      - key: DOWNLOAD SIZE
+        value: 17GB
+      - key: LLM ENGINE
+        value: VLLM
   labels:
   - Multimodal
   - Vision-Language

--- a/models/public/1.58.0/gpt-oss.yaml
+++ b/models/public/1.58.0/gpt-oss.yaml
@@ -801,6 +801,126 @@ models:
         value: 13GB
       - key: LLM ENGINE
         value: VLLM
+    - profileId: nim/openai/gpt-oss-20b:hf-d666cf3-nim-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: GPT-OSS 20B RTX6000_BLACKWELL_SVx1 MXFP4
+      ngcMetadata:
+        66fb3113efd2aae1b0a3bfa2a375de5fe1cc1b557abac4eb271730482a26ae8e:
+          model: openai/gpt-oss-20b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            nim_workspace_hash_v1: bef4d428df8c3e67ebe56ba2050a0f50216e82c0172407b43c99c1f6befc9fc5
+            pp: '1'
+            precision: mxfp4
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: MXFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 13GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/openai/gpt-oss-20b:hf-d666cf3-nim-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: GPT-OSS 20B RTX6000_BLACKWELL_SVx2 MXFP4
+      ngcMetadata:
+        c3035169e189674226b284a07173f495b6ce13f2a06d5ea204f1e505c2fac2be:
+          model: openai/gpt-oss-20b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            nim_workspace_hash_v1: bef4d428df8c3e67ebe56ba2050a0f50216e82c0172407b43c99c1f6befc9fc5
+            pp: '1'
+            precision: mxfp4
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: MXFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 13GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/openai/gpt-oss-20b:hf-d666cf3-nim-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: GPT-OSS 20B RTX6000_BLACKWELL_SVx4 MXFP4
+      ngcMetadata:
+        653e98d21f9274306416d736519e1c0442d9dad9d8756ff1134cbededfd43323:
+          model: openai/gpt-oss-20b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            nim_workspace_hash_v1: bef4d428df8c3e67ebe56ba2050a0f50216e82c0172407b43c99c1f6befc9fc5
+            pp: '1'
+            precision: mxfp4
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: MXFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 13GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/openai/gpt-oss-20b:hf-d666cf3-nim-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: GPT-OSS 20B RTX6000_BLACKWELL_SVx8 MXFP4
+      ngcMetadata:
+        66b8ec445352535aa8c640435d6f7b00fb2cabb70f8d39fc371adb00322907df:
+          model: openai/gpt-oss-20b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            nim_workspace_hash_v1: bef4d428df8c3e67ebe56ba2050a0f50216e82c0172407b43c99c1f6befc9fc5
+            pp: '1'
+            precision: mxfp4
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: MXFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 13GB
+      - key: LLM ENGINE
+        value: VLLM
   - variantId: GPT-OSS 120B
     modelCard: ewogICAgImFjY2Vzc1R5cGUiOiAiTk9UX0xJU1RFRCIsCiAgICAiYXBwbGljYXRpb24iOiAiT3RoZXIiLAogICAgImJpYXMiOiAiIiwKICAgICJjYW5HdWVzdERvd25sb2FkIjogZmFsc2UsCiAgICAiY3JlYXRlZERhdGUiOiAiMjAyNS0wOC0wNVQxOTozNzowNi4zMzBaIiwKICAgICJkZXNjcmlwdGlvbiI6ICIjIEdQVCBPU1MgMTIwQiBPdmVydmlld1xuXG4jIyBEZXNjcmlwdGlvbjogPGJyPlxuT3BlbkFJIHJlbGVhc2VzIHRoZSBncHQtb3NzIGZhbWlseSBvZiBvcGVuLXdlaWdodCBtb2RlbHMgZGVzaWduZWQgZm9yIHBvd2VyZnVsIHJlYXNvbmluZywgYWdlbnRpYyB0YXNrcywgYW5kIHZlcnNhdGlsZSBkZXZlbG9wZXIgdXNlIGNhc2VzLiBUaGUgZmFtaWx5IGNvbnNpc3RzIG9mIHRoZTpcbi0gYGdwdC1vc3MtMTIwYmAgXHUyMDE0IGZvciBwcm9kdWN0aW9uLCBnZW5lcmFsIHB1cnBvc2UsIGhpZ2ggcmVhc29uaW5nIHVzZS1jYXNlcyB0aGF0IGZpdHMgaW50byBhIHNpbmdsZSBIMTAwIEdQVSAoMTE3QiBwYXJhbWV0ZXJzIHdpdGggNS4xQiBhY3RpdmUgcGFyYW1ldGVycylcbi0gYGdwdC1vc3MtMjBiYCBcdTIwMTQgZm9yIGxvd2VyIGxhdGVuY3ksIGFuZCBsb2NhbCBvciBzcGVjaWFsaXplZCB1c2UtY2FzZXMgKDIxQiBwYXJhbWV0ZXJzIHdpdGggMy42QiBhY3RpdmUgcGFyYW1ldGVycykuXG5cblRoZSBgZ3B0LW9zcy0xMjBiYCBtb2RlbCBpcyBhcmNoaXRlY3R1cmFsbHkgZGVzaWduZWQgYXMgYSBNaXh0dXJlLW9mLUV4cGVydHMgKE1vRSkgbW9kZWwuIFRoaXMgbW9kZWwgZmVhdHVyZXMgU3dpR0xVIGFjdGl2YXRpb25zIGFuZCBsZWFybmVkIGF0dGVudGlvbiBzaW5rcyB3aXRoaW4gaXRzIGFyY2hpdGVjdHVyZS4gSXQgZnVuY3Rpb25zIGFzIGEgcmVhc29uaW5nIG1vZGVsLCBzdXBwb3J0aW5nIGNhcGFiaWxpdGllcyBzdWNoIGFzIGNoYWluLW9mLXRob3VnaHQgcHJvY2Vzc2luZywgYWRqdXN0YWJsZSByZWFzb25pbmcgZWZmb3J0IGxldmVscywgaW5zdHJ1Y3Rpb24gZm9sbG93aW5nLCBhbmQgdG9vbCB1c2UuIFRoaXMgbW9kZWwgaXMgdGV4dC1vbmx5IGZvciBib3RoIGlucHV0IGFuZCBvdXRwdXQgbW9kYWxpdGllcywgZW5hYmxpbmcgZW50ZXJwcmlzZXMgYW5kIGdvdmVybm1lbnRzIHRvIGRlcGxveSBpdCBvbi1wcmVtaXNlcyBvciBpbiBwcml2YXRlIGNsb3VkIGVudmlyb25tZW50cyBmb3IgZW5oYW5jZWQgZGF0YSBzZWN1cml0eSBhbmQgcHJpdmFjeS5cblxuTW9kZWwgSGlnaGxpZ2h0czogIFxuLSAqKlBlcm1pc3NpdmUgQXBhY2hlIDIuMCBsaWNlbnNlOioqIEJ1aWxkIGZyZWVseSB3aXRob3V0IGNvcHlsZWZ0IHJlc3RyaWN0aW9ucyBvciBwYXRlbnQgcmlza1x1MjAxNGlkZWFsIGZvciBleHBlcmltZW50YXRpb24sIGN1c3RvbWl6YXRpb24sIGFuZCBjb21tZXJjaWFsIGRlcGxveW1lbnQuXG4tICoqQ29uZmlndXJhYmxlIHJlYXNvbmluZyBlZmZvcnQ6KiogRWFzaWx5IGFkanVzdCB0aGUgcmVhc29uaW5nIGVmZm9ydCAobG93LCBtZWRpdW0sIGhpZ2gpIGJhc2VkIG9uIHlvdXIgc3BlY2lmaWMgdXNlIGNhc2UgYW5kIGxhdGVuY3kgbmVlZHMuXG4tICoqRnVsbCBjaGFpbi1vZi10aG91Z2h0OioqIEdhaW4gY29tcGxldGUgYWNjZXNzIHRvIHRoZSBtb2RlbCdzIHJlYXNvbmluZyBwcm9jZXNzLCBmYWNpbGl0YXRpbmcgZWFzaWVyIGRlYnVnZ2luZyBhbmQgaW5jcmVhc2VkIHRydXN0IGluIG91dHB1dHMuIEl0J3Mgbm90IGludGVuZGVkIHRvIGJlIHNob3duIHRvIGVuZCB1c2Vycy5cbi0gKipGaW5lLXR1bmFibGU6KiogRnVsbHkgY3VzdG9taXplIG1vZGVscyB0byB5b3VyIHNwZWNpZmljIHVzZSBjYXNlIHRocm91Z2ggcGFyYW1ldGVyIGZpbmUtdHVuaW5nLlxuLSAqKkFnZW50aWMgY2FwYWJpbGl0aWVzOioqIFVzZSB0aGUgbW9kZWxzJyBuYXRpdmUgY2FwYWJpbGl0aWVzIGZvciBmdW5jdGlvbiBjYWxsaW5nLCB3ZWIgYnJvd3NpbmcsIHB5dGhvbiBjb2RlIGV4ZWN1dGlvbiwgYW5kIHN0cnVjdHVyZWQgb3V0cHV0cy5cblxuVGhpcyBtb2RlbCBpcyByZWFkeSBmb3IgY29tbWVyY2lhbC9ub24tY29tbWVyY2lhbCB1c2UuXG5cblxuIyMgVGhpcmQtUGFydHkgQ29tbXVuaXR5IENvbnNpZGVyYXRpb24gPGJyPlxuVGhpcyBtb2RlbCBpcyBub3Qgb3duZWQgb3IgZGV2ZWxvcGVkIGJ5IE5WSURJQS4gVGhpcyBtb2RlbCBoYXMgYmVlbiBkZXZlbG9wZWQgYW5kIGJ1aWx0IHRvIGEgdGhpcmQtcGFydHlcdTIwMTlzIHJlcXVpcmVtZW50cyBmb3IgdGhpcyBhcHBsaWNhdGlvbiBhbmQgdXNlIGNhc2U7IHNlZSBsaW5rIHRvIE5vbi1OVklESUEgW2dwdC1vc3MtMTIwYiBtb2RlbCBjYXJkXShodHRwczovL2h1Z2dpbmdmYWNlLmNvL29wZW5haS9ncHQtb3NzLTEyMGIpLlxuXG5cbiMjIyBMaWNlbnNlIGFuZCBUZXJtcyBvZiBVc2U6IDxicj5cbkdPVkVSTklORyBURVJNUzogVGhlIE5JTSBjb250YWluZXIgaXMgZ292ZXJuZWQgYnkgdGhlIFtOVklESUEgU29mdHdhcmUgTGljZW5zZSBBZ3JlZW1lbnRdKGF0IGh0dHBzOi8vd3d3Lm52aWRpYS5jb20vZW4tdXMvYWdyZWVtZW50cy9lbnRlcnByaXNlLXNvZnR3YXJlL252aWRpYS1zb2Z0d2FyZS1saWNlbnNlLWFncmVlbWVudC8pIGFuZCB0aGUgW1Byb2R1Y3QtU3BlY2lmaWMgVGVybXMgZm9yIE5WSURJQSBBSSBQcm9kdWN0c10oaHR0cHM6Ly93d3cubnZpZGlhLmNvbS9lbi11cy9hZ3JlZW1lbnRzL2VudGVycHJpc2Utc29mdHdhcmUvcHJvZHVjdC1zcGVjaWZpYy10ZXJtcy1mb3ItYWktcHJvZHVjdHMvKTsgYW5kIHRoZSB1c2Ugb2YgdGhpcyBtb2RlbCBpcyBnb3Zlcm5lZCBieSB0aGUgW05WSURJQSBDb21tdW5pdHkgTW9kZWwgTGljZW5zZSBBZ3JlZW1lbnRdKGh0dHBzOi8vd3d3Lm52aWRpYS5jb20vZW4tdXMvYWdyZWVtZW50cy9lbnRlcnByaXNlLXNvZnR3YXJlL252aWRpYS1jb21tdW5pdHktbW9kZWxzLWxpY2Vuc2UvKS5cbkFkZGl0aW9uYWwgSW5mb3JtYXRpb246IFtBcGFjaGUgTGljZW5zZSBWZXJzaW9uIDIuMF0oaHR0cHM6Ly93d3cuYXBhY2hlLm9yZy9saWNlbnNlcy9MSUNFTlNFLTIuMCkuXG5cbioqWW91IGFyZSByZXNwb25zaWJsZSBmb3IgZW5zdXJpbmcgdGhhdCB5b3VyIHVzZSBvZiBOVklESUEgcHJvdmlkZWQgbW9kZWxzIGNvbXBsaWVzIHdpdGggYWxsIGFwcGxpY2FibGUgbGF3cyoqXG5cbiMjIEdldCBIZWxwXG5cbiMjIyBFbnRlcnByaXNlIFN1cHBvcnRcblxuR2V0IGFjY2VzcyB0byBrbm93bGVkZ2UgYmFzZSBhcnRpY2xlcyBhbmQgc3VwcG9ydCBjYXNlcyBvciBbc3VibWl0IGEgdGlja2V0XShodHRwczovL3d3dy5udmlkaWEuY29tL2VuLXVzL2RhdGEtY2VudGVyL3Byb2R1Y3RzL2FpLWVudGVycHJpc2Utc3VpdGUvc3VwcG9ydC8pLlxuXG4jIyMgTlZJRElBIE5JTSBEb2N1bWVudGF0aW9uXG5cblZpc2l0IHRoZSBbTklNIENvbnRhaW5lciBMTE1dKGh0dHBzOi8vZG9jcy5udmlkaWEuY29tL25pbS9sYXJnZS1sYW5ndWFnZS1tb2RlbHMvbGF0ZXN0L2ludHJvZHVjdGlvbi5odG1sKSBwYWdlIGZvciByZWxlYXNlIGRvY3VtZW50YXRpb24sIGRlcGxveW1lbnQgZ3VpZGVzIGFuZCBtb3JlLlxuXG4jIyMgRGVwbG95bWVudCBHZW9ncmFwaHk6XG5HbG9iYWxcblxuIyMjIFVzZSBDYXNlOiA8YnI+XG5JbnRlbmRlZCBmb3IgdXNlIGFzIGEgcmVhc29uaW5nIG1vZGVsIHdpdGggZmVhdHVyZXMgbGlrZSBjaGFpbi1vZi10aG91Z2h0IGFuZCBhZGp1c3RhYmxlIHJlYXNvbmluZyBlZmZvcnQgbGV2ZWxzLiBJdCBzdXBwb3J0cyBpbnN0cnVjdGlvbiBmb2xsb3dpbmcgYW5kIHRvb2wgdXNlLCBvZmZlcmluZyB0cmFuc3BhcmVuY3ksIGN1c3RvbWl6YXRpb24sIGFuZCBkZXBsb3ltZW50IGZsZXhpYmlsaXR5IGZvciBkZXZlbG9wZXJzLCByZXNlYXJjaGVycywgYW5kIHN0YXJ0dXBzLiBBZGRpdGlvbmFsbHksIGl0IGVuYWJsZXMgZW50ZXJwcmlzZXMgYW5kIGdvdmVybm1lbnRzIHRvIGRlcGxveSBvbi1wcmVtaXNlcyBvciBpbiBwcml2YXRlIGNsb3VkcyB0byBlbnN1cmUgZGF0YSBzZWN1cml0eSBhbmQgcHJpdmFjeS5cblxuIyMjIFJlbGVhc2UgRGF0ZTogIDxicj5cbkJ1aWxkLk5WSURJQS5jb20gLSAwOC8wNS8yMDI1IHZpYSBbbGlua10oaHR0cHM6Ly9idWlsZC5udmlkaWEuY29tL29wZW5haS9ncHQtb3NzLTEyMGIpIDxicj4gXG5IdWdnaW5nIEZhY2UgLSAwOC8wNS8yMDI1IHZpYSBbbGlua10oaHR0cHM6Ly9odWdnaW5nZmFjZS5jby9vcGVuYWkvZ3B0LW9zcy0xMjBiKSA8YnI+XG5cbiMjIFJlZmVyZW5jZShzKTpcbi0gW09wZW5BSSBDb29rYm9va10oaHR0cHM6Ly9jb29rYm9vay5vcGVuYWkuY29tLylcbi0gW09wZW4gQUkgQ29vYmtib29rIC0tIFNlcnZpbmcgTW9kZWwgd2l0aCBUZW5zb3JSVC1MTE1dKGh0dHBzOi8vY29va2Jvb2sub3BlbmFpLmNvbS9hcnRpY2xlcy9ncHQtb3NzL3J1bi1udmlkaWEpXG5cblxuIyMgTW9kZWwgQXJjaGl0ZWN0dXJlOiA8YnI+IFxuKipBcmNoaXRlY3R1cmUgVHlwZToqKiBUcmFuc2Zvcm1lciA8YnI+XG4qKk5ldHdvcmsgQXJjaGl0ZWN0dXJlOioqIE1peHR1cmUtb2YtRXhwZXJ0cyAoTW9FKSA8YnI+XG4qKlRvdGFsIFBhcmFtZXRlcnM6KiogMTE3QiA8YnI+XG4qKkFjdGl2ZSBQYXJhbWV0ZXJzOioqIDUuN0IgPGJyPlxuKipWb2NhYnVsYXJ5IFNpemU6KiogMjAxLDA4OCA8YnI+XG5cblxuIyMgSW5wdXQ6IDxicj5cbioqSW5wdXQgVHlwZShzKToqKiBUZXh0IDxicj5cbioqSW5wdXQgRm9ybWF0KHMpOioqIFN0cmluZyA8YnI+XG4qKklucHV0IFBhcmFtZXRlcnM6KiogT25lIERpbWVuc2lvbmFsICgxRCkgPGJyPlxuKipPdGhlciBQcm9wZXJ0aWVzIFJlbGF0ZWQgdG8gSW5wdXQ6KiogVXNlcyBSb1BFIHdpdGggYSAxMjhrIGNvbnRleHQgbGVuZ3RoLCB3aXRoIGF0dGVudGlvbiBsYXllcnMgYWx0ZXJuYXRpbmcgYmV0d2VlbiBmdWxsIGNvbnRleHQgYW5kIGEgc2xpZGluZyAxMjgtdG9rZW4gd2luZG93LiBJbmNsdWRlcyBhIGxlYXJuZWQgYXR0ZW50aW9uIHNpbmsgcGVyLWhlYWQuIEVtcGxveXMgU3dpR0xVIGFjdGl2YXRpb25zIGluIHRoZSBNb0UgbGF5ZXJzLCBhbmQgdGhlIHJvdXRlciBwZXJmb3JtcyBhIFRvcC1LIG9wZXJhdGlvbiAoSz00KSBmb2xsb3dlZCBieSBhIFNpZ21vaWQgZnVuY3Rpb24uIEdFTU1zIGluIHRoZSBNb0UgaW5jbHVkZSBhIHBlci1leHBlcnQgYmlhcy4gVXRpbGl6ZXMgdGlrdG9rZW4gZm9yIHRva2VuaXphdGlvbi4gSW5wdXQgQ29udGV4dCBMZW5ndGggKElTTCk6IDEyODAwMCA8YnI+XG5cbiMjIE91dHB1dDogPGJyPlxuKipPdXRwdXQgVHlwZShzKToqKiBUZXh0IDxicj5cbioqT3V0cHV0IEZvcm1hdDoqKiBTdHJpbmcgPGJyPlxuKipPdXRwdXQgUGFyYW1ldGVyczoqKiBPbmUgRGltZW5zaW9uYWwgKDFEKSA8YnI+XG4qKk90aGVyIFByb3BlcnRpZXMgUmVsYXRlZCB0byBPdXRwdXQ6KiogVGhlIG1vZGVsIGlzIGRlc2lnbmVkIHRvIGJlIGNvbXBhdGlibGUgd2l0aCB0aGUgT3BlbkFJIFJlc3BvbnNlcyBBUEkgYW5kIHN1cHBvcnRzIFN0cnVjdHVyZWQgT3V0cHV0LiA8YnI+IFxuXG5PdXIgQUkgbW9kZWxzIGFyZSBkZXNpZ25lZCBhbmQvb3Igb3B0aW1pemVkIHRvIHJ1biBvbiBOVklESUEgR1BVLWFjY2VsZXJhdGVkIHN5c3RlbXMgW29yIG5hbWUgZXF1aXZhbGVudCBoYXJkd2FyZSBwcmVmZXJlbmNlXS4gQnkgbGV2ZXJhZ2luZyBOVklESUFcdTIwMTlzIGhhcmR3YXJlIChlLmcuIEdQVSBjb3JlcykgYW5kIHNvZnR3YXJlIGZyYW1ld29ya3MgKGUuZy4sIENVREEgbGlicmFyaWVzKSwgdGhlIG1vZGVsIGFjaGlldmVzIGZhc3RlciB0cmFpbmluZyBhbmQgaW5mZXJlbmNlIHRpbWVzIGNvbXBhcmVkIHRvIENQVS1vbmx5IHNvbHV0aW9ucy4gPGJyPiAgIFxuXG4jIyBTb2Z0d2FyZSBJbnRlZ3JhdGlvbjogPGJyPlxuKipSdW50aW1lIEVuZ2luZShzKToqKiA8YnI+XG4qIE5lTW8gRnJhbWV3b3JrIChiYXNlZCBvbiAyNS4wNyk8YnI+XG5cblxuKipTdXBwb3J0ZWQgSGFyZHdhcmUgTWljcm9hcmNoaXRlY3R1cmUgQ29tcGF0aWJpbGl0eToqKiA8YnI+XG4qIE5WSURJQSBCbGFja3dlbGw6IEIyMDAgPGJyPlxuKiBOVklESUEgSG9wcGVyOiBIMjAwXG5cblxuKipPcGVyYXRpbmcgU3lzdGVtKHMpOioqIExpbnV4IFxuXG4jIyBNb2RlbCBWZXJzaW9uKHMpOiBcbmBncHQtb3NzLTEyMGJgIHYxLjAgKEF1Z3VzdCA1LCAyMDI1KVxuXG5cbiMjIFRyYWluaW5nLCBUZXN0aW5nLCBhbmQgRXZhbHVhdGlvbiBEYXRhc2V0czogPGJyPiAgIFxuIyMjIFRyYWluaW5nIERhdGFzZXQ6XG5cbiogKipUcmFpbmluZyBEYXRhIENvbGxlY3Rpb246KiogVW5kaXNjbG9zZWQgPGJyPlxuKiAqKlRyYWluaW5nIExhYmVsaW5nOioqIFVuZGlzY2xvc2VkIDxicj5cbiogKipUcmFpbmluZyBQcm9wZXJ0aWVzOioqIFRoZSBtb2RlbCBoYXMgYXBwcm94aW1hdGVseSAxMTcgYmlsbGlvbiBwYXJhbWV0ZXJzLiBXZWlnaHRzIGZvciBhbGwgbGF5ZXJzIGFyZSBpbiBCRjE2LCBleGNlcHQgZm9yIE1vRSBwcm9qZWN0aW9uIHdlaWdodHMsIHdoaWNoIGFyZSBpbiBNWEZQNC4gVGhlIHJlZmVyZW5jZSBpbXBsZW1lbnRhdGlvbiBjdXJyZW50bHkgdXBjYXN0cyBhbGwgd2VpZ2h0cyB0byBCRjE2LiBBY3RpdmF0aW9ucyBhcmUgZXhwZWN0ZWQgdG8gYmUgaW4gQkYxNiBvciBGUDguXG5cblxuIyMjIFRlc3RpbmcgRGF0YXNldDpcbiogKipUZXN0aW5nIERhdGEgQ29sbGVjdGlvbjoqKiBVbmRpc2Nsb3NlZCA8YnI+XG4qICoqVGVzdGluZyBMYWJlbGluZzoqKiBVbmRpc2Nsb3NlZCA8YnI+XG4qICoqVGVzdGluZyBQcm9wZXJ0aWVzOioqIFRoZSBtb2RlbCBpcyB0ZXN0ZWQgYWdhaW5zdCBiZW5jaG1hcmtzIHN1Y2ggYXMgTU1MVSBhbmQgR1BRQSwgYW1vbmcgb3RoZXJzIGluY2x1ZGluZyBMaXZlQ29kZUJlbmNoLCBBSU1FIDIwMjQsIGFuZCBNQVRILTUwMC4gXG5cbiMjIyBFdmFsdWF0aW9uIERhdGFzZXQ6XG5cbiogKipFdmFsdWF0aW9uIERhdGEgQ29sbGVjdGlvbjoqKiBVbmRpc2Nsb3NlZCA8YnI+XG4qICoqRXZhbHVhdGlvbiBMYWJlbGluZzoqKiBVbmRpc2Nsb3NlZCA8YnI+XG4qICoqRXZhbHVhdGlvbiBCZW5jaG1hcmsgU2NvcmU6KiogXG5cbnwgQmVuY2htYXJrICB8IGdwdC1vc3MtMTIwYiB8IGdwdC1vc3MtMjBiIHxcbnwtLS0tLS0tLS0tfC0tLS0tLS0tLS0tfCAtLS0tLS0tLS0tLXxcbnwgQUlNRSAyMDI0IChubyB0b29scykgfCA5NS44ICAgfCA5Mi4xIHxcbnwgQUlNRSAyMDI0ICh3aXRoIHRvb2xzKSB8IDk2LjYgfCA5Ni4wIHxcbnwgQUlNRSAyMDI1IChubyB0b29scykgfCA5Mi41ICB8IDkxLjcgfFxufCBBSU1FIDIwMjUgKHdpdGggdG9vbHMpIHwgOTcuOSB8IDk4LjcgfFxufCBHUFFBIERpYW1vbmQgKG5vIHRvb2xzKSB8IDgwLjEgfCA3MS41IHxcbnwgR1BRQSBEaWFtb25kICh3aXRoIHRvb2xzKSB8IDgwLjkgfCA3NC4yIHxcbnwgSExFIChubyB0b29scykgfCAxNC45IHwgMTAuOSB8XG58IEhMRSAod2l0aCB0b29scykgfCAxOS4wIHwgMTcuMyB8XG58IE1NTFUgfCA5MC4wIHwgODUuMyB8XG58IFNXRS1CZW5jaCBWZXJpZmllZCB8IDYyLjQgfCA2MC43IHxcbnwgVGF1LUJlbmNoIFJldGFpbCB8IDY3LjggfCA1NC40IHxcbnwgVGF1LUJlbmNoIEFpcmxpbmUgfCA0OS4yIHwgMzguMCB8XG58IEFpZGVyIFBvbHlnbG90IHwgNDQuNCB8IDM0LjIgfFxufCBNTU1MVSAoQXZlcmFnZSkgfCA4MS4zIHwgNzUuNiB8XG58IEhlYWx0aEJlbmNoIHwgNTcuNiB8IDQyLjUgfFxufCBIZWFsdGhCZW5jaCBIYXJkIHwgMzAuMCB8IDEwLjggfFxufCBIZWFsdGhCZW5jaCBDb25zZW5zdXMgfCA4OS45IHwgODIuNiB8XG58IENvZGVmb3JjZXMgKG5vIHRvb2xzKSBbZWxvXSB8IDI0NjMgfCAyMjMwIHxcbnwgQ29kZWZvcmNlcyAod2l0aCB0b29scykgW2Vsb10gfCAyNjIyIHwgMjUxNiB8XG5cbkFib3ZlIHNjb3JlcyB3ZXJlIG1lYXN1cmVkIGZvciB0aGUgaGlnaCByZWFzb25pbmcgbGV2ZWwuXG5cbiMjIyBTYWZldHkgUmVzdWx0czpcblxuVGhlIGZvbGxvd2luZyBldmFsdWF0aW9ucyBjaGVjayB0aGF0IHRoZSBtb2RlbCBkb2VzIG5vdCBjb21wbHkgd2l0aCByZXF1ZXN0cyBmb3IgY29udGVudCB0aGF0IGlzXG5kaXNhbGxvd2VkIHVuZGVyIE9wZW5BSVx1MjAxOXMgc2FmZXR5IHBvbGljaWVzLCBpbmNsdWRpbmcgaGF0ZWZ1bCBjb250ZW50IG9yIGlsbGljaXQgYWR2aWNlLlxuXG58IENhdGVnb3J5ICB8IGdwdC1vc3MtMTIwYiB8IGdwdC1vc3MtMjBiIHxcbnwtLS0tLS0tLS0tfC0tLS0tLS0tLS0tfCAtLS0tLS0tLS0tLXxcbnwgaGF0ZSAoYWdncmVnYXRlKSB8IDAuOTk2ICAgfCAwLjk5NiB8XG58IHNlbGYtaGFybS9pbnRlbnQgYW5kIHNlbGZoYXJtL2luc3RydWN0aW9ucyB8IDAuOTk1IHwgMC45ODQgfFxufCBwZXJzb25hbCBkYXRhL3NlbWkgcmVzdHJpY3RpdmUgfCAwLjk2NyAgfCAwLjk0NyB8XG58IHNleHVhbC9leHBsb2l0YXRpdmUgfCAxLjAwMCB8IDAuOTgwIHxcbnwgc2V4dWFsL21pbm9ycyB8IDEuMDAwIHwgMC45NzEgfFxufCBpbGxpY2l0L25vbi12aW9sZW50IHwgMS4wMDAgfCAwLjk4MyB8XG58IGlsbGljaXQvdmlvbGVudCB8IDEuMDAwIHwgMS4wMDAgfFxufCBwZXJzb25hbCBkYXRhL3Jlc3RyaWN0ZWQgfCAwLjk5NiB8IDAuOTc4IHxcblxuIyMgSW5mZXJlbmNlOlxuKipBY2NlbGVyYXRpb24gRW5naW5lOioqIHZMTE0gPGJyPlxuKipUZXN0IEhhcmR3YXJlOioqIE5WSURJQSBIb3BwZXI6IEIyMDAgPGJyPlxuXG5cbiMjIEFkZGl0aW9uYWwgRGV0YWlsc1xuVGhlIG1vZGVsIGlzIHJlbGVhc2VkIHdpdGggdGhlIG5hdGl2ZSBxdWFudGl6YXRpb24gc3VwcG9ydC4gU3BlY2lmaWNhbGx5LCBbTVhGUDRdKGh0dHBzOi8vd3d3Lm9wZW5jb21wdXRlLm9yZy9kb2N1bWVudHMvb2NwLW1pY3Jvc2NhbGluZy1mb3JtYXRzLW14LXYxLTAtc3BlYy1maW5hbC1wZGYpIGlzIHVzZWQgZm9yIHRoZSBsaW5lYXIgcHJvamVjdGlvbiB3ZWlnaHRzIGluIHRoZSBNb0UgbGF5ZXIuIEl0IGlzIHN0b3JlZCB0aGUgTW9FIHRlbnNvciBpbiB0d28gcGFydHM6XG5cbi0gYHRlbnNvci5ibG9ja3NgIHN0b3JlcyB0aGUgYWN0dWFsIGZwNCB2YWx1ZXMuIEV2ZXJ5IHR3byB2YWx1ZXMgYXJlIHBhY2tlZCBpbiBvbmUgYHVpbnQ4YCB2YWx1ZS5cbi0gYHRlbnNvci5zY2FsZXNgIHN0b3JlcyB0aGUgYmxvY2sgc2NhbGUuIFRoZSBibG9jayBzY2FsaW5nIGlzIGRvbmUgYW1vbmcgdGhlIGxhc3QgZGltZW5zaW9uIGZvciBhbGwgTVhGUDQgdGVuc29ycy5cblxuQWxsIG90aGVyIHRlbnNvcnMgYXJlIHN0b3JlZCBpbiBCRjE2LiBJdCBpcyByZWNvbW1lbmRlZCB0byB1c2UgQkYxNiBhcyB0aGUgYWN0aXZhdGlvbiBwcmVjaXNpb24gZm9yIHRoZSBtb2RlbC5cblxuIyMgRXRoaWNhbCBDb25zaWRlcmF0aW9uczpcbk5WSURJQSBiZWxpZXZlcyBUcnVzdHdvcnRoeSBBSSBpcyBhIHNoYXJlZCByZXNwb25zaWJpbGl0eSBhbmQgd2UgaGF2ZSBlc3RhYmxpc2hlZCBwb2xpY2llcyBhbmQgcHJhY3RpY2VzIHRvIGVuYWJsZSBkZXZlbG9wbWVudCBmb3IgYSB3aWRlIGFycmF5IG9mIEFJIGFwcGxpY2F0aW9ucy4gIFdoZW4gZG93bmxvYWRlZCBvciB1c2VkIGluIGFjY29yZGFuY2Ugd2l0aCBvdXIgdGVybXMgb2Ygc2VydmljZSwgZGV2ZWxvcGVycyBzaG91bGQgd29yayB3aXRoIHRoZWlyIGludGVybmFsIG1vZGVsIHRlYW0gdG8gZW5zdXJlIHRoaXMgbW9kZWwgbWVldHMgcmVxdWlyZW1lbnRzIGZvciB0aGUgcmVsZXZhbnQgaW5kdXN0cnkgYW5kIHVzZSBjYXNlIGFuZCBhZGRyZXNzZXMgdW5mb3Jlc2VlbiBwcm9kdWN0IG1pc3VzZS4gIFxuXG5QbGVhc2UgcmVwb3J0IHNlY3VyaXR5IHZ1bG5lcmFiaWxpdGllcyBvciBOVklESUEgQUkgQ29uY2VybnMgW2hlcmVdKGh0dHBzOi8vd3d3Lm52aWRpYS5jb20vZW4tdXMvc3VwcG9ydC9zdWJtaXQtc2VjdXJpdHktdnVsbmVyYWJpbGl0eS8pLiIsCiAgICAiZGlzcGxheU5hbWUiOiAiR1BULU9TUy0xMjBCIiwKICAgICJleHBsYWluYWJpbGl0eSI6ICIiLAogICAgImZyYW1ld29yayI6ICJPdGhlciIsCiAgICAiaGFzUGxheWdyb3VuZCI6IGZhbHNlLAogICAgImhhc1NpZ25lZFZlcnNpb24iOiB0cnVlLAogICAgImlzUGxheWdyb3VuZEVuYWJsZWQiOiBmYWxzZSwKICAgICJpc1B1YmxpYyI6IGZhbHNlLAogICAgImlzUmVhZE9ubHkiOiB0cnVlLAogICAgImxhYmVscyI6IFsKICAgICAgICAiTlNQRUNULUVFWlMtN0pCTSIsCiAgICAgICAgIlNpZ25lZCBNb2RlbHMiLAogICAgICAgICJudmFpZTptb2RlbDpudmFpZV9zdXBwb3J0ZWQiLAogICAgICAgICJudmlkaWFfbmltOm1vZGVsOm5pbW1jcm9fbnZpZGlhX25pbSIsCiAgICAgICAgInByb2R1Y3ROYW1lczpuaW0tZGV2IiwKICAgICAgICAicHJvZHVjdE5hbWVzOm52LWFpLWVudGVycHJpc2UiCiAgICBdLAogICAgImxhdGVzdFZlcnNpb25JZFN0ciI6ICJoZi04YjE5M2IwLW5pbSIsCiAgICAibGF0ZXN0VmVyc2lvblNpemVJbkJ5dGVzIjogNjUyNzY4NTk4NzUsCiAgICAibG9nbyI6ICJodHRwczovL2Fzc2V0cy5uZ2MubnZpZGlhLmNvbS9wcm9kdWN0cy9hcGktY2F0YWxvZy9pbWFnZXMvZ3B0LW9zcy0xMjBiLmpwZyIsCiAgICAibW9kZWxGb3JtYXQiOiAiU2F2ZWRNb2RlbCIsCiAgICAibmFtZSI6ICJncHQtb3NzLTEyMGIiLAogICAgIm9yZ05hbWUiOiAibmltIiwKICAgICJwcmVjaXNpb24iOiAiT1RIRVIiLAogICAgInByaXZhY3kiOiAiIiwKICAgICJwcm9kdWN0TmFtZXMiOiBbCiAgICAgICAgIm5pbS1kZXYiLAogICAgICAgICJudi1haS1lbnRlcnByaXNlIgogICAgXSwKICAgICJwdWJsaWNEYXRhc2V0VXNlZCI6IHt9LAogICAgInB1Ymxpc2hlciI6ICJPcGVuQUkiLAogICAgInNhZmV0eUFuZFNlY3VyaXR5IjogIiIsCiAgICAic2hvcnREZXNjcmlwdGlvbiI6ICJPcGVuQUkgcmVsZWFzZXMgdGhlIGdwdC1vc3MgZmFtaWx5IG9mIG9wZW4td2VpZ2h0IG1vZGVscyBkZXNpZ25lZCBmb3IgcG93ZXJmdWwgcmVhc29uaW5nLCBhZ2VudGljIHRhc2tzLCBhbmQgdmVyc2F0aWxlIGRldmVsb3BlciB1c2UgY2FzZXMuIiwKICAgICJ0ZWFtTmFtZSI6ICJvcGVuYWkiLAogICAgInVwZGF0ZWREYXRlIjogIjIwMjUtMDktMDRUMjA6MTU6MTguNzQ4WiIKfQ==
     source:
@@ -1488,6 +1608,126 @@ models:
         value: 8
       - key: GPU DEVICE
         value: 26B9:10DE
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 61GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/openai/gpt-oss-120b:hf-8b193b0-nim-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: GPT-OSS 120B RTX6000_BLACKWELL_SVx1 MXFP4
+      ngcMetadata:
+        7ee480d91bf63c0d1595758d3bd76d4aeaaa5395e8f049ea6893fa55a0cf1268:
+          model: openai/gpt-oss-120b
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '243.0'
+            pp: '1'
+            precision: mxfp4
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: MXFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 61GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/openai/gpt-oss-120b:hf-8b193b0-nim-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: GPT-OSS 120B RTX6000_BLACKWELL_SVx2 MXFP4
+      ngcMetadata:
+        6d13f5550d09f7ea938153a2740238d850afed7c9ed9efdb8887982dc7fd31a0:
+          model: openai/gpt-oss-120b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '127.0'
+            pp: '1'
+            precision: mxfp4
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: MXFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 61GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/openai/gpt-oss-120b:hf-8b193b0-nim-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: GPT-OSS 120B RTX6000_BLACKWELL_SVx4 MXFP4
+      ngcMetadata:
+        41b9c476d251bd06e92d98ffb8f22329059d878ce319e7c776ee51d3bacd153a:
+          model: openai/gpt-oss-120b
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '69.0'
+            pp: '1'
+            precision: mxfp4
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: MXFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 61GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/openai/gpt-oss-120b:hf-8b193b0-nim-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: GPT-OSS 120B RTX6000_BLACKWELL_SVx8 MXFP4
+      ngcMetadata:
+        1c82e31a9fdb6f8cad58b9a9fc561c23fd2074a183b47e51548335514f99a610:
+          model: openai/gpt-oss-120b
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '40.0'
+            pp: '1'
+            precision: mxfp4
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: MXFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
       - key: NIM VERSION
         value: 2.0.3
       - key: DOWNLOAD SIZE

--- a/models/public/1.58.0/llama-3.1-instruct.yaml
+++ b/models/public/1.58.0/llama-3.1-instruct.yaml
@@ -867,6 +867,247 @@ models:
         value: 9GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
+    - profileId: nim/meta/llama-3.1-8b-instruct-pb25h2:8c22764a7e3675c50d4c7c9a4edb474456022b16_pb25h2-rtx6000_blackwell_sv__5
+      framework: VLLM
+      displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx1 BF16
+      ngcMetadata:
+        925771095bbfd8bca1cc2a1ea4a91ecba85b2d68493f0dad3b85bb6c209d8730:
+          model: meta/llama-3.1-8b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'true'
+            feat_lora_max_rank: '32'
+            llm_engine: vllm
+            nim_workspace_hash_v1: e6913c5e344dca0d1286eb01a7f7b0016bb14d50e0bca8fef5a30c08a0d75144
+            pp: '1'
+            precision: bf16
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 30GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.1-8b-instruct-pb25h2:8c22764a7e3675c50d4c7c9a4edb474456022b16_pb25h2-rtx6000_blackwell_sv
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx1 BF16 Throughput
+      ngcMetadata:
+        010bb9e16e9322ddce6db6e6a7d8c844c0ec2ed3d8358a0127dc4cf1114c724a:
+          model: meta/llama-3.1-8b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 555b1cabcde42da61eb1cb14883d71f6e921dd1f171183f7ad27680f45c0412f
+            number_of_gpus: '1'
+            pp: '1'
+            precision: bf16
+            profile: throughput
+            tp: '1'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: THROUGHPUT
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 30GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/meta/llama-3.1-8b-instruct-pb25h2:8c22764a7e3675c50d4c7c9a4edb474456022b16_pb25h2-rtx6000_blackwell_sv__2
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx1 FP8 Latency
+      ngcMetadata:
+        0a929ddd7dadd0bed6a633e6b2ec1e6a90a92ccb60fbe3dd36be97f17328e965:
+          model: meta/llama-3.1-8b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: d61e398017263380bfabf947395e155a35ea873a0a95e468fcf30fdfcb2274fd
+            number_of_gpus: '1'
+            pp: '1'
+            precision: fp8
+            profile: latency
+            tp: '1'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: LATENCY
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 30GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/meta/llama-3.1-8b-instruct-pb25h2:8c22764a7e3675c50d4c7c9a4edb474456022b16_pb25h2-rtx6000_blackwell_sv__3
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx1 FP8 Throughput
+      ngcMetadata:
+        31b9c56ca65e6e6e74b3b95dc2233994b78b309c6733a84a485d4cdf8eccc44f:
+          model: meta/llama-3.1-8b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 1f65528a87318fc0ba52aff1a6bed8ea2f986c187e1c3b04c83c5de589b08510
+            number_of_gpus: '1'
+            pp: '1'
+            precision: fp8
+            profile: throughput
+            tp: '1'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: THROUGHPUT
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 30GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/meta/llama-3.1-8b-instruct-pb25h2:8c22764a7e3675c50d4c7c9a4edb474456022b16_pb25h2-rtx6000_blackwell_sv__4
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx1 NVFP4 Throughput
+      ngcMetadata:
+        c7fdb92819af3784195c1be4fd64e2b005281bbf16ad0735c1485050676d4709:
+          model: meta/llama-3.1-8b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 7d02d59a43df163111196b1b019050502069e6c7444fbc65daaf51558bc28f45
+            number_of_gpus: '1'
+            pp: '1'
+            precision: nvfp4
+            profile: throughput
+            tp: '1'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: THROUGHPUT
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 30GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/meta/llama-3.1-8b-instruct-pb25h2:8c22764a7e3675c50d4c7c9a4edb474456022b16_pb25h2-rtx6000_blackwell_sv-tp2__2
+      framework: VLLM
+      displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx2 BF16
+      ngcMetadata:
+        4bf63ad29ec25417108c5fe1f00ee86ea129334e3cd05c7f7e0d862146d2fc2d:
+          model: meta/llama-3.1-8b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            nim_workspace_hash_v1: e6913c5e344dca0d1286eb01a7f7b0016bb14d50e0bca8fef5a30c08a0d75144
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 30GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.1-8b-instruct-pb25h2:8c22764a7e3675c50d4c7c9a4edb474456022b16_pb25h2-rtx6000_blackwell_sv-tp2
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx2 BF16 Latency
+      ngcMetadata:
+        742e4dd3cab8b08be915776df631f67b3a52aea40c4466e009e0fc457b7c137b:
+          model: meta/llama-3.1-8b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: f0073ef6d193a4fd768a55cd04fbc9fbcd949546c2e94010f2ed11e08d299c91
+            number_of_gpus: '2'
+            pp: '1'
+            precision: bf16
+            profile: latency
+            tp: '2'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: LATENCY
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 30GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
   - variantId: Llama 3.1 70B Instruct
     modelCard: ewogICAgImFjY2Vzc1R5cGUiOiAiTk9UX0xJU1RFRCIsCiAgICAiYXBwbGljYXRpb24iOiAiT3RoZXIiLAogICAgImJpYXMiOiAiIiwKICAgICJjYW5HdWVzdERvd25sb2FkIjogZmFsc2UsCiAgICAiY3JlYXRlZERhdGUiOiAiMjAyNS0wNS0yMFQxODoxNzowOS4xMDdaIiwKICAgICJkZXNjcmlwdGlvbiI6ICIjICoqTGxhbWEtMy4xLTcwQi1JbnN0cnVjdCBPdmVydmlldyoqXG5cbiMjICoqRGVzY3JpcHRpb246KipcblxuKipMbGFtYS0zLjEtNzBCLUluc3RydWN0KiogaXMgYSBtdWx0aWxpbmd1YWwgbGFyZ2UgbGFuZ3VhZ2UgbW9kZWwgZnJvbSB0aGUgTWV0YSBMbGFtYSAzLjEgY29sbGVjdGlvbiBvZiBwcmV0cmFpbmVkIGFuZCBpbnN0cnVjdGlvbi10dW5lZCBnZW5lcmF0aXZlIG1vZGVscy4gVGhpcyBtb2RlbCBpcyBvcHRpbWl6ZWQgZm9yIG11bHRpbGluZ3VhbCBkaWFsb2d1ZSB1c2UgY2FzZXMgYW5kIG91dHBlcmZvcm1zIG1hbnkgYXZhaWxhYmxlIG9wZW4tc291cmNlIGFuZCBjbG9zZWQtc291cmNlIGNoYXQgbW9kZWxzIG9uIGNvbW1vbiBpbmR1c3RyeSBiZW5jaG1hcmtzLiBMbGFtYSAzLjEgaXMgYW4gYXV0by1yZWdyZXNzaXZlIGxhbmd1YWdlIG1vZGVsIHRoYXQgdXNlcyBhbiBvcHRpbWl6ZWQgdHJhbnNmb3JtZXIgYXJjaGl0ZWN0dXJlOyB0aGUgdHVuZWQgdmVyc2lvbnMgdXNlIHN1cGVydmlzZWQgZmluZS10dW5pbmcgKFNGVCkgYW5kIHJlaW5mb3JjZW1lbnQgbGVhcm5pbmcgd2l0aCBodW1hbiBmZWVkYmFjayAoUkxIRikgdG8gYWxpZ24gd2l0aCBodW1hbiBwcmVmZXJlbmNlcyBmb3IgaGVscGZ1bG5lc3MgYW5kIHNhZmV0eS5cblxuVGhpcyBtb2RlbCBpcyByZWFkeSBmb3IgY29tbWVyY2lhbC9ub24tY29tbWVyY2lhbCB1c2UuXG5cblRoaXMgdmVyc2lvbiBpbnRyb2R1Y2VzIHN1cHBvcnQgZm9yIEdCMjAwIE5WTDcyLCBHSDIwMCBOVkwyLCBCMjAwIGFuZCBOVkZQNC4gQ1VEQSB1cGRhdGVkIHRvIHZlcnNpb24gMTIuOS4gRm9yIGRldGFpbGVkIGluZm9ybWF0aW9uLCByZWZlciB0byBSZWxlYXNlIFtOb3RlcyBmb3IgTlZJRElBIE5JTSBmb3IgTExNcyBMTE0gMS4xMl0oaHR0cHM6Ly9kb2NzLm52aWRpYS5jb20vbmltL2xhcmdlLWxhbmd1YWdlLW1vZGVscy9sYXRlc3QvcmVsZWFzZS1ub3Rlcy5odG1sKS4gXG5cbiMjICoqVGhpcmQtUGFydHkgQ29tbXVuaXR5IENvbnNpZGVyYXRpb24qKlxuXG5UaGlzIG1vZGVsIGlzIG5vdCBvd25lZCBvciBkZXZlbG9wZWQgYnkgTlZJRElBLiBUaGlzIG1vZGVsIGhhcyBiZWVuIGRldmVsb3BlZCBhbmQgYnVpbHQgdG8gYSB0aGlyZC1wYXJ0eSdzIHJlcXVpcmVtZW50cyBmb3IgdGhpcyBhcHBsaWNhdGlvbiBhbmQgdXNlIGNhc2U7IHNlZSBsaW5rIHRvIE5vbi1OVklESUFcXFttZXRhLWxsYW1hL0xsYW1hLTMuMS03MEItSW5zdHJ1Y3RcXF0gIFxuKFtodHRwczovL2h1Z2dpbmdmYWNlLmNvL21ldGEtbGxhbWEvTGxhbWEtMy4xLTcwQi1JbnN0cnVjdF0oaHR0cHM6Ly9odWdnaW5nZmFjZS5jby9tZXRhLWxsYW1hL0xsYW1hLTMuMS03MEItSW5zdHJ1Y3QpKS4gXG5cbiMjICoqTGljZW5zZS9UZXJtcyBvZiBVc2U6KipcblxuKipHT1ZFUk5JTkcgVEVSTVM6KiogVGhlIE5JTSBjb250YWluZXIgaXMgZ292ZXJuZWQgYnkgdGhlIFtOVklESUEgU29mdHdhcmUgTGljZW5zZSBBZ3JlZW1lbnRdKGh0dHBzOi8vd3d3Lm52aWRpYS5jb20vZW4tdXMvYWdyZWVtZW50cy9lbnRlcnByaXNlLXNvZnR3YXJlL252aWRpYS1zb2Z0d2FyZS1saWNlbnNlLWFncmVlbWVudC8pIGFuZCB0aGUgW1Byb2R1Y3QtU3BlY2lmaWMgVGVybXMgZm9yIE5WSURJQSBBSSBQcm9kdWN0c10oaHR0cHM6Ly93d3cubnZpZGlhLmNvbS9lbi11cy9hZ3JlZW1lbnRzL2VudGVycHJpc2Utc29mdHdhcmUvcHJvZHVjdC1zcGVjaWZpYy10ZXJtcy1mb3ItYWktcHJvZHVjdHMvKTsgYW5kIHRoZSB1c2Ugb2YgdGhlIG1vZGVsIGlzIGdvdmVybmVkIGJ5IHRoZSBbTlZJRElBIENvbW11bml0eSBNb2RlbCBMaWNlbnNlIEFncmVlbWVudF0oaHR0cHM6Ly93d3cubnZpZGlhLmNvbS9lbi11cy9hZ3JlZW1lbnRzL2VudGVycHJpc2Utc29mdHdhcmUvbnZpZGlhLWNvbW11bml0eS1tb2RlbHMtbGljZW5zZS8uKS5cblxuKipBRERJVElPTkFMIElORk9STUFUSU9OOioqIFtMbGFtYSAzLjEgQ29tbXVuaXR5IExpY2Vuc2UgQWdyZWVtZW50XShodHRwczovL3d3dy5sbGFtYS5jb20vbGxhbWEzXzMvbGljZW5zZS8pLiBCdWlsdCB3aXRoIExsYW1hLlxuXG4jIyBHZXQgSGVscFxuXG4jIyMgRW50ZXJwcmlzZSBTdXBwb3J0XG5cbkdldCBhY2Nlc3MgdG8ga25vd2xlZGdlIGJhc2UgYXJ0aWNsZXMgYW5kIHN1cHBvcnQgY2FzZXMgb3IgW3N1Ym1pdCBhIHRpY2tldF0oaHR0cHM6Ly93d3cubnZpZGlhLmNvbS9lbi11cy9kYXRhLWNlbnRlci9wcm9kdWN0cy9haS1lbnRlcnByaXNlLXN1aXRlL3N1cHBvcnQvKS5cblxuKipZb3UgYXJlIHJlc3BvbnNpYmxlIGZvciBlbnN1cmluZyB0aGF0IHlvdXIgdXNlIG9mIE5WSURJQSBwcm92aWRlZCBtb2RlbHMgY29tcGxpZXMgd2l0aCBhbGwgYXBwbGljYWJsZSBsYXdzLioqXG5cbiMjICoqRGVwbG95bWVudCBHZW9ncmFwaHk6KipcblxuR2xvYmFsIFxuXG4jIyAqKlVzZSBDYXNlOioqXG5cbkRldmVsb3BlcnMsIEFJIHJlc2VhcmNoZXJzLCBhbmQgYnVzaW5lc3NlcyB3b3VsZCBiZSBleHBlY3RlZCB0byB1c2UgdGhpcyBzeXN0ZW0gdG8gYnVpbGQgYW5kIHBvd2VyIGEgd2lkZSByYW5nZSBvZiBhcHBsaWNhdGlvbnMgdGhhdCByZXF1aXJlIGFkdmFuY2VkIHJlYXNvbmluZywgaW5zdHJ1Y3Rpb24tZm9sbG93aW5nLCBhbmQgbXVsdGlsaW5ndWFsIGRpYWxvZ3VlIGNhcGFiaWxpdGllcy4gU3BlY2lmaWMgYXBwbGljYXRpb25zIGluY2x1ZGUgY3JlYXRpbmcgc29waGlzdGljYXRlZCBjaGF0Ym90cyBhbmQgdmlydHVhbCBhc3Npc3RhbnRzLCBkZXZlbG9waW5nIHBvd2VyZnVsIGNvbnRlbnQgY3JlYXRpb24gYW5kIHN1bW1hcml6YXRpb24gdG9vbHMsIGJ1aWxkaW5nIGNvbXBsZXggcXVlc3Rpb24tYW5zd2VyaW5nIHN5c3RlbXMsIGFuZCBwb3dlcmluZyBtdWx0aWxpbmd1YWwgY3VzdG9tZXIgc3VwcG9ydCBwbGF0Zm9ybXMuXG5cbiMjICoqUmVsZWFzZSBEYXRlOioqXG5cbkJ1aWxkLk52aWRpYS5jb20gMDcvMjMvMjAyNCB2aWEgIFxuW2xsYW1hLTMuMS03MGItaW5zdHJ1Y3QgTW9kZWwgYnkgTWV0YSB8IE5WSURJQSBOSU1dKGh0dHBzOi8vYnVpbGQubnZpZGlhLmNvbS9tZXRhL2xsYW1hLTNfMS03MGItaW5zdHJ1Y3QpXG5cbkdpdGh1YiAwNy8yMy8yMDI0IHZpYSAgIFxuW2h0dHBzOi8vZ2l0aHViLmNvbS9tZXRhLWxsYW1hL2xsYW1hLW1vZGVscy9ibG9iL21haW4vbW9kZWxzL2xsYW1hM1xcXzEvTElDRU5TRV0oaHR0cHM6Ly9naXRodWIuY29tL21ldGEtbGxhbWEvbGxhbWEtbW9kZWxzL2Jsb2IvbWFpbi9tb2RlbHMvbGxhbWEzXzEvTElDRU5TRSlcblxuSHVnZ2luZ2ZhY2UgMDcvMjMvMjAyNCB2aWEgICBcbltodHRwczovL2h1Z2dpbmdmYWNlLmNvL21ldGEtbGxhbWEvTGxhbWEtMy4xLTcwQi1JbnN0cnVjdF0oaHR0cHM6Ly9odWdnaW5nZmFjZS5jby9tZXRhLWxsYW1hL0xsYW1hLTMuMS03MEItSW5zdHJ1Y3QpXG5cbioqUmVmZXJlbmNlKHMpOioqIFxuXG5baHR0cHM6Ly9odWdnaW5nZmFjZS5jby9tZXRhLWxsYW1hL0xsYW1hLTMuMS03MEItSW5zdHJ1Y3RdKGh0dHBzOi8vaHVnZ2luZ2ZhY2UuY28vbWV0YS1sbGFtYS9MbGFtYS0zLjEtNzBCLUluc3RydWN0KVxuXG4jIyAqKk1vZGVsIEFyY2hpdGVjdHVyZToqKiBcblxuQXJjaGl0ZWN0dXJlIFR5cGU6IFRyYW5zZm9ybWVyICBcbk5ldHdvcmsgQXJjaGl0ZWN0dXJlOiBMbGFtYS0zLjEtNzBCXG5cblRoaXMgbW9kZWwgd2FzIGRldmVsb3BlZCBiYXNlZCBvbiBNZXRhLUxsYW1hLTMuMS03MEIgIFxuW2h0dHBzOi8vaHVnZ2luZ2ZhY2UuY28vbWV0YS1sbGFtYS9MbGFtYS0zLjEtNzBCLUluc3RydWN0XShodHRwczovL2h1Z2dpbmdmYWNlLmNvL21ldGEtbGxhbWEvTGxhbWEtMy4xLTcwQi1JbnN0cnVjdClcblxuTnVtYmVyIG9mIG1vZGVsIHBhcmFtZXRlcnM6IDcuMDYqMTBeMTBcblxuIyMgKipJbnB1dDoqKlxuXG5JbnB1dCBUeXBlKHMpOiBUZXh0IFxuXG5JbnB1dCBGb3JtYXQocyk6IFN0cmluZyBcblxuSW5wdXQgUGFyYW1ldGVyczogT25lLURpbWVuc2lvbmFsICgxRClcblxuT3RoZXIgUHJvcGVydGllcyBSZWxhdGVkIHRvIElucHV0OiBUaGUgbW9kZWwgYWNjZXB0cyBhIHN0cmluZyBvZiB0ZXh0IHdoaWNoIGlzIGNvbnZlcnRlZCBpbnRvIHRva2VucyB1c2luZyB0aGUgbW9kZWwncyBzcGVjaWZpYyB0b2tlbml6ZXIuIFRoZSB0b3RhbCBsZW5ndGggb2YgdGhlIGlucHV0IHByb21wdCBhbmQgdGhlIGdlbmVyYXRlZCBvdXRwdXQgY2Fubm90IGV4Y2VlZCB0aGUgbW9kZWwncyBjb250ZXh0IHdpbmRvdyBvZiAxMjgsMDAwIHRva2Vucy5cblxuIyMgKipPdXRwdXQ6KipcblxuT3V0cHV0IFR5cGUocyk6IFRleHQgXG5cbk91dHB1dCBGb3JtYXQocyk6IFN0cmluZ1xuXG5PdXRwdXQgUGFyYW1ldGVyczogT25lLURpbWVuc2lvbmFsICgxRClcblxuT3RoZXIgUHJvcGVydGllcyBSZWxhdGVkIHRvIE91dHB1dDogVGhlIG1vZGVsIGdlbmVyYXRlcyBhIHN0cmluZyBvZiB0ZXh0LCBwcm9kdWNlZCB0b2tlbiBieSB0b2tlbi4gVGhlIG1heGltdW0gbGVuZ3RoIG9mIHRoZSBvdXRwdXQgaXMgbGltaXRlZCBieSB0aGUgbW9kZWwncyAxMjgsMDAwLXRva2VuIGNvbnRleHQgd2luZG93LCBsZXNzIHRoZSBsZW5ndGggb2YgdGhlIGlucHV0IHByb21wdC4gUG9zdC1wcm9jZXNzaW5nIGlzIHJlcXVpcmVkIHRvIGRlY29kZSB0aGUgbW9kZWwncyB0b2tlbi1iYXNlZCBvdXRwdXQgaW50byBhIHJlYWRhYmxlIHN0cmluZy5cblxuT3VyIEFJIG1vZGVscyBhcmUgZGVzaWduZWQgYW5kL29yIG9wdGltaXplZCB0byBydW4gb24gTlZJRElBIEdQVS1hY2NlbGVyYXRlZCBzeXN0ZW1zLiBCeSBsZXZlcmFnaW5nIE5WSURJQSdzIGhhcmR3YXJlIChlLmcuIEdQVSBjb3JlcykgYW5kIHNvZnR3YXJlIGZyYW1ld29ya3MgKGUuZy4sIENVREEgbGlicmFyaWVzKSwgdGhlIG1vZGVsIGFjaGlldmVzIGZhc3RlciB0cmFpbmluZyBhbmQgaW5mZXJlbmNlIHRpbWVzIGNvbXBhcmVkIHRvIENQVS1vbmx5IHNvbHV0aW9ucy5cblxuIyMgKipTb2Z0d2FyZSBJbnRlZ3JhdGlvbjoqKlxuXG5SdW50aW1lIEVuZ2luZTogdkxMTSwgVGVuc29yUlRcblxuU3VwcG9ydGVkIEhhcmR3YXJlIE1pY3JvYXJjaGl0ZWN0dXJlIENvbXBhdGliaWxpdHk6XG5cbk5WSURJQSBBbXBlcmUgIFxuTlZJRElBIEJsYWNrd2VsbCAgXG5OVklESUEgSG9wcGVyICBcbk5WSURJQSBMb3ZlbGFjZSBcblxuUHJlZmVycmVkIE9wZXJhdGluZyBTeXN0ZW0ocyk6XG5cbkxpbnV4ICAgXG5XaW5kb3dzXG5cblRoZSBpbnRlZ3JhdGlvbiBvZiBmb3VuZGF0aW9uIGFuZCBmaW5lLXR1bmVkIG1vZGVscyBpbnRvIEFJIHN5c3RlbXMgcmVxdWlyZXMgYWRkaXRpb25hbCB0ZXN0aW5nIHVzaW5nIHVzZS1jYXNlLXNwZWNpZmljIGRhdGEgdG8gZW5zdXJlIHNhZmUgYW5kIGVmZmVjdGl2ZSBkZXBsb3ltZW50LiBGb2xsb3dpbmcgdGhlIFYtbW9kZWwgbWV0aG9kb2xvZ3ksIGl0ZXJhdGl2ZSB0ZXN0aW5nIGFuZCB2YWxpZGF0aW9uIGF0IGJvdGggdW5pdCBhbmQgc3lzdGVtIGxldmVscyBhcmUgZXNzZW50aWFsIHRvIG1pdGlnYXRlIHJpc2tzLCBtZWV0IHRlY2huaWNhbCBhbmQgZnVuY3Rpb25hbCByZXF1aXJlbWVudHMsIGFuZCBlbnN1cmUgY29tcGxpYW5jZSB3aXRoIHNhZmV0eSBhbmQgZXRoaWNhbCBzdGFuZGFyZHMgYmVmb3JlIGRlcGxveW1lbnQuXG5cbiMjICoqTW9kZWwgVmVyc2lvbihzKToqKlxuXG5MbGFtYS0zLjEtNzBCLUluc3RydWN0XG5cbiMjICoqVXNhZ2UqKlxuXG4qKlVzZSB3aXRoIHRyYW5zZm9ybWVycyoqXG5cblN0YXJ0aW5nIHdpdGggdHJhbnNmb3JtZXJzIFxcPj0gNC40NS4wIG9ud2FyZCwgeW91IGNhbiBydW4gY29udmVyc2F0aW9uYWwgaW5mZXJlbmNlIHVzaW5nIHRoZSBUcmFuc2Zvcm1lcnMgcGlwZWxpbmUgYWJzdHJhY3Rpb24gb3IgYnkgbGV2ZXJhZ2luZyB0aGUgQXV0byBjbGFzc2VzIHdpdGggdGhlIGdlbmVyYXRlKCkgZnVuY3Rpb24uXG5cbk1ha2Ugc3VyZSB0byB1cGRhdGUgeW91ciB0cmFuc2Zvcm1lcnMgaW5zdGFsbGF0aW9uIHZpYSBwaXAgaW5zdGFsbCBcXC0tdXBncmFkZSB0cmFuc2Zvcm1lcnMuXG5cblNlZSB0aGUgc25pcHBldCBiZWxvdyBmb3IgdXNhZ2Ugd2l0aCBUcmFuc2Zvcm1lcnM6XG5cbmBgYFxuaW1wb3J0IHRyYW5zZm9ybWVyc1xuaW1wb3J0IHRvcmNoXG5cbm1vZGVsX2lkID0gXCJtZXRhLWxsYW1hL01ldGEtTGxhbWEtMy4xLTcwQi1JbnN0cnVjdFwiXG5cbnBpcGVsaW5lID0gdHJhbnNmb3JtZXJzLnBpcGVsaW5lKFxuICAgIFwidGV4dC1nZW5lcmF0aW9uXCIsXG4gICAgbW9kZWw9bW9kZWxfaWQsXG4gICAgbW9kZWxfa3dhcmdzPXtcInRvcmNoX2R0eXBlXCI6IHRvcmNoLmJmbG9hdDE2fSxcbiAgICBkZXZpY2VfbWFwPVwiYXV0b1wiLFxuKVxuXG5tZXNzYWdlcyA9IFtcbiAgICB7XCJyb2xlXCI6IFwic3lzdGVtXCIsIFwiY29udGVudFwiOiBcIllvdSBhcmUgYSBwaXJhdGUgY2hhdGJvdCB3aG8gYWx3YXlzIHJlc3BvbmRzIGluIHBpcmF0ZSBzcGVhayFcIn0sXG4gICAge1wicm9sZVwiOiBcInVzZXJcIiwgXCJjb250ZW50XCI6IFwiV2hvIGFyZSB5b3U/XCJ9LFxuXVxuXG5vdXRwdXRzID0gcGlwZWxpbmUoXG4gICAgbWVzc2FnZXMsXG4gICAgbWF4X25ld190b2tlbnM9MjU2LFxuKVxucHJpbnQob3V0cHV0c1swXVtcImdlbmVyYXRlZF90ZXh0XCJdWy0xXSlcbmBgYFxuXG4qKlRvb2wgdXNlIHdpdGggdHJhbnNmb3JtZXJzKipcblxuTExhTUEtMy4zIHN1cHBvcnRzIG11bHRpcGxlIHRvb2wgdXNlIGZvcm1hdHMuIFlvdSBjYW4gc2VlIGEgZnVsbCBndWlkZSB0byBwcm9tcHQgZm9ybWF0dGluZyBbaGVyZV0oaHR0cHM6Ly9sbGFtYS5tZXRhLmNvbS9kb2NzL21vZGVsLWNhcmRzLWFuZC1wcm9tcHQtZm9ybWF0cy9sbGFtYTNfMS8pLlxuXG5Ub29sIHVzZSBpcyBhbHNvIHN1cHBvcnRlZCB0aHJvdWdoIFtjaGF0IHRlbXBsYXRlc10oaHR0cHM6Ly9odWdnaW5nZmFjZS5jby9kb2NzL3RyYW5zZm9ybWVycy9tYWluL2NoYXRfdGVtcGxhdGluZyNhZHZhbmNlZC10b29sLXVzZS0tZnVuY3Rpb24tY2FsbGluZykgaW4gVHJhbnNmb3JtZXJzLiBIZXJlIGlzIGEgcXVpY2sgZXhhbXBsZSBzaG93aW5nIGEgc2luZ2xlIHNpbXBsZSB0b29sOlxuXG5gYGBcbiMgRmlyc3QsIGRlZmluZSBhIHRvb2xcbmRlZiBnZXRfY3VycmVudF90ZW1wZXJhdHVyZShsb2NhdGlvbjogc3RyKSAtPiBmbG9hdDpcbiAgICBcIlwiXCJcbiAgICBHZXQgdGhlIGN1cnJlbnQgdGVtcGVyYXR1cmUgYXQgYSBsb2NhdGlvbi5cbiAgICBcbiAgICBBcmdzOlxuICAgICAgICBsb2NhdGlvbjogVGhlIGxvY2F0aW9uIHRvIGdldCB0aGUgdGVtcGVyYXR1cmUgZm9yLCBpbiB0aGUgZm9ybWF0IFwiQ2l0eSwgQ291bnRyeVwiXG4gICAgUmV0dXJuczpcbiAgICAgICAgVGhlIGN1cnJlbnQgdGVtcGVyYXR1cmUgYXQgdGhlIHNwZWNpZmllZCBsb2NhdGlvbiBpbiB0aGUgc3BlY2lmaWVkIHVuaXRzLCBhcyBhIGZsb2F0LlxuICAgIFwiXCJcIlxuICAgIHJldHVybiAyMi4gICMgQSByZWFsIGZ1bmN0aW9uIHNob3VsZCBwcm9iYWJseSBhY3R1YWxseSBnZXQgdGhlIHRlbXBlcmF0dXJlIVxuXG4jIE5leHQsIGNyZWF0ZSBhIGNoYXQgYW5kIGFwcGx5IHRoZSBjaGF0IHRlbXBsYXRlXG5tZXNzYWdlcyA9IFtcbiAge1wicm9sZVwiOiBcInN5c3RlbVwiLCBcImNvbnRlbnRcIjogXCJZb3UgYXJlIGEgYm90IHRoYXQgcmVzcG9uZHMgdG8gd2VhdGhlciBxdWVyaWVzLlwifSxcbiAge1wicm9sZVwiOiBcInVzZXJcIiwgXCJjb250ZW50XCI6IFwiSGV5LCB3aGF0J3MgdGhlIHRlbXBlcmF0dXJlIGluIFBhcmlzIHJpZ2h0IG5vdz9cIn1cbl1cblxuaW5wdXRzID0gdG9rZW5pemVyLmFwcGx5X2NoYXRfdGVtcGxhdGUobWVzc2FnZXMsIHRvb2xzPVtnZXRfY3VycmVudF90ZW1wZXJhdHVyZV0sIGFkZF9nZW5lcmF0aW9uX3Byb21wdD1UcnVlKVxuYGBgXG5cbllvdSBjYW4gdGhlbiBnZW5lcmF0ZSB0ZXh0IGZyb20gdGhpcyBpbnB1dCBhcyBub3JtYWwuIElmIHRoZSBtb2RlbCBnZW5lcmF0ZXMgYSB0b29sIGNhbGwsIHlvdSBzaG91bGQgYWRkIGl0IHRvIHRoZSBjaGF0IGxpa2Ugc286XG5cbmBgYFxudG9vbF9jYWxsID0ge1wibmFtZVwiOiBcImdldF9jdXJyZW50X3RlbXBlcmF0dXJlXCIsIFwiYXJndW1lbnRzXCI6IHtcImxvY2F0aW9uXCI6IFwiUGFyaXMsIEZyYW5jZVwifX1cbm1lc3NhZ2VzLmFwcGVuZCh7XCJyb2xlXCI6IFwiYXNzaXN0YW50XCIsIFwidG9vbF9jYWxsc1wiOiBbe1widHlwZVwiOiBcImZ1bmN0aW9uXCIsIFwiZnVuY3Rpb25cIjogdG9vbF9jYWxsfV19KVxuYGBgXG5cbmFuZCB0aGVuIGNhbGwgdGhlIHRvb2wgYW5kIGFwcGVuZCB0aGUgcmVzdWx0LCB3aXRoIHRoZSB0b29sIHJvbGUsIGxpa2Ugc286XG5cbmBgYFxubWVzc2FnZXMuYXBwZW5kKHtcInJvbGVcIjogXCJ0b29sXCIsIFwibmFtZVwiOiBcImdldF9jdXJyZW50X3RlbXBlcmF0dXJlXCIsIFwiY29udGVudFwiOiBcIjIyLjBcIn0pXG5gYGBcblxuQWZ0ZXIgdGhhdCwgeW91IGNhbiBnZW5lcmF0ZSgpIGFnYWluIHRvIGxldCB0aGUgbW9kZWwgdXNlIHRoZSB0b29sIHJlc3VsdCBpbiB0aGUgY2hhdC4gTm90ZSB0aGF0IHRoaXMgd2FzIGEgdmVyeSBicmllZiBpbnRyb2R1Y3Rpb24gdG8gdG9vbCBjYWxsaW5nIFxcLSBmb3IgbW9yZSBpbmZvcm1hdGlvbiwgc2VlIHRoZSBbTExhTUEgcHJvbXB0IGZvcm1hdCBkb2NzXShodHRwczovL2xsYW1hLm1ldGEuY29tL2RvY3MvbW9kZWwtY2FyZHMtYW5kLXByb21wdC1mb3JtYXRzL2xsYW1hM18xLykgYW5kIHRoZSBUcmFuc2Zvcm1lcnMgW3Rvb2wgdXNlIGRvY3VtZW50YXRpb25dKGh0dHBzOi8vaHVnZ2luZ2ZhY2UuY28vZG9jcy90cmFuc2Zvcm1lcnMvbWFpbi9jaGF0X3RlbXBsYXRpbmcjYWR2YW5jZWQtdG9vbC11c2UtLWZ1bmN0aW9uLWNhbGxpbmcpLlxuXG4qKlVzZSB3aXRoIGJpdHNhbmRieXRlcyoqXG5cblRoZSBtb2RlbCBjaGVja3BvaW50cyBjYW4gYmUgdXNlZCBpbiA4LWJpdCBhbmQgNC1iaXQgZm9yIGZ1cnRoZXIgbWVtb3J5IG9wdGltaXNhdGlvbnMgdXNpbmcgYml0c2FuZGJ5dGVzIGFuZCB0cmFuc2Zvcm1lcnNcblxuU2VlIHRoZSBzbmlwcGV0IGJlbG93IGZvciB1c2FnZTpcblxuYGBgXG5pbXBvcnQgdG9yY2hcbmZyb20gdHJhbnNmb3JtZXJzIGltcG9ydCBBdXRvTW9kZWxGb3JDYXVzYWxMTSwgQXV0b1Rva2VuaXplclxuXG5tb2RlbF9pZCA9IFwibWV0YS1sbGFtYS9NZXRhLUxsYW1hLTMuMS03MEItSW5zdHJ1Y3RcIlxucXVhbnRpemF0aW9uX2NvbmZpZyA9IEJpdHNBbmRCeXRlc0NvbmZpZyhsb2FkX2luXzhiaXQ9VHJ1ZSlcblxucXVhbnRpemVkX21vZGVsID0gQXV0b01vZGVsRm9yQ2F1c2FsTE0uZnJvbV9wcmV0cmFpbmVkKFxuICAgIG1vZGVsX2lkLCBkZXZpY2VfbWFwPVwiYXV0b1wiLCB0b3JjaF9kdHlwZT10b3JjaC5iZmxvYXQxNiwgcXVhbnRpemF0aW9uX2NvbmZpZz1xdWFudGl6YXRpb25fY29uZmlnKVxuXG50b2tlbml6ZXIgPSBBdXRvVG9rZW5pemVyLmZyb21fcHJldHJhaW5lZChtb2RlbF9pZClcbmlucHV0X3RleHQgPSBcIldoYXQgYXJlIHdlIGhhdmluZyBmb3IgZGlubmVyP1wiXG5pbnB1dF9pZHMgPSB0b2tlbml6ZXIoaW5wdXRfdGV4dCwgcmV0dXJuX3RlbnNvcnM9XCJwdFwiKS50byhcImN1ZGFcIilcblxub3V0cHV0ID0gcXVhbnRpemVkX21vZGVsLmdlbmVyYXRlKCoqaW5wdXRfaWRzLCBtYXhfbmV3X3Rva2Vucz0xMClcblxucHJpbnQodG9rZW5pemVyLmRlY29kZShvdXRwdXRbMF0sIHNraXBfc3BlY2lhbF90b2tlbnM9VHJ1ZSkpXG5gYGBcblxuVG8gbG9hZCBpbiA0LWJpdCBzaW1wbHkgcGFzcyBsb2FkXFxfaW5cXF80Yml0PVRydWVcblxuKipVc2Ugd2l0aCBsbGFtYSoqXG5cblBsZWFzZSwgZm9sbG93IHRoZSBpbnN0cnVjdGlvbnMgaW4gdGhlIFtyZXBvc2l0b3J5XShodHRwczovL2dpdGh1Yi5jb20vbWV0YS1sbGFtYS9sbGFtYSkuXG5cblRvIGRvd25sb2FkIE9yaWdpbmFsIGNoZWNrcG9pbnRzLCBzZWUgdGhlIGV4YW1wbGUgY29tbWFuZCBiZWxvdyBsZXZlcmFnaW5nIGh1Z2dpbmdmYWNlLWNsaTpcblxuYGBgXG5odWdnaW5nZmFjZS1jbGkgZG93bmxvYWQgbWV0YS1sbGFtYS9NZXRhLUxsYW1hLTMuMS03MEItSW5zdHJ1Y3QgLS1pbmNsdWRlIFwib3JpZ2luYWwvKlwiIC0tbG9jYWwtZGlyIE1ldGEtTGxhbWEtMy4xLTcwQi1JbnN0cnVjdFxuYGBgXG5cbiMjICoqVHJhaW5pbmcsIFRlc3RpbmcsIGFuZCBFdmFsdWF0aW9uIERhdGFzZXRzOioqXG5cbiMjIyAqKlRyYWluaW5nIERhdGFzZXQqKlxuXG4qKkRhdGEgTW9kYWxpdHk6KiogVGV4dCBcblxuKipMaW5rOioqIFVuZGlzY2xvc2VkXG5cbioqRGF0YSBDb2xsZWN0aW9uIE1ldGhvZDoqKiBIeWJyaWQ6IEh1bWFuLCBTeW50aGV0aWMsIEF1dG9tYXRlZFxuXG4qKkxhYmVsaW5nIE1ldGhvZDoqKiBIeWJyaWQ6IEF1dG9tYXRlZCwgSHVtYW5cblxuKipQcm9wZXJ0aWVzOioqIFxuXG5UaGUgcHJldHJhaW5pbmcgZGF0YXNldCBjb250YWlucyBvdmVyIDE1IHRyaWxsaW9uIHRva2Vucy4gSXQgaXMgYSBtdWx0aWxpbmd1YWwgZGF0YXNldCBjb3ZlcmluZyBvdmVyIDMwIGxhbmd1YWdlcyBhbmQgd2FzIGZpbHRlcmVkIGhlYXZpbHkgZm9yIHF1YWxpdHkgdXNpbmcgdmFyaW91cyB0ZWNobmlxdWVzLCBpbmNsdWRpbmcgaGV1cmlzdGljIGZpbHRlcnMsIE5TRlcgZmlsdGVycywgYW5kIHRleHQgY2xhc3NpZmllcnMuIFRoZSBtb2RlbCdzIGtub3dsZWRnZSB3YXMgdHJhaW5lZCBvbiBkYXRhIHdpdGggYSBjdXRvZmYgb2YgRGVjZW1iZXIgMjAyM1xcLiBcblxuIyMjICoqVGVzdGluZyBEYXRhc2V0KipcblxuKipMaW5rOioqIFVuZGlzY2xvc2VkXG5cbioqRGF0YSBDb2xsZWN0aW9uIE1ldGhvZDoqKiBIeWJyaWQ6IEh1bWFuLCBTeW50aGV0aWMsIEF1dG9tYXRlZFxuXG4qKkxhYmVsaW5nIE1ldGhvZDoqKiBIeWJyaWQ6IEF1dG9tYXRlZCwgSHVtYW5cblxuKipQcm9wZXJ0aWVzOioqIFxuXG4qKkRlc2NyaXB0aW9uOioqXG5cblRoZSBtb2RlbCB3YXMgdGVzdGVkIG9uIGEgZGl2ZXJzZSBzZXQgb2YgZXZhbHVhdGlvbiBkYXRhLlxuXG4qIFB1YmxpYyBCZW5jaG1hcmtzOiBUaGVzZSB0ZXN0IGEgd2lkZSByYW5nZSBvZiBjYXBhYmlsaXRpZXMsIGZyb20gZ2VuZXJhbCBrbm93bGVkZ2UgYW5kIHJlYXNvbmluZyAoTU1MVSwgSGVsbGFTd2FnKSB0byBleHBlcnQtbGV2ZWwgcHJvYmxlbS1zb2x2aW5nIChHUFFBKSBhbmQgcHJvZ3JhbW1pbmcgKEh1bWFuRXZhbCwgd2hpY2ggY29udGFpbnMgMTY0IHByb2dyYW1taW5nIHByb2JsZW1zKS4gIFxuKiBJbnRlcm5hbCBFdmFsdWF0aW9uIFNldDogTWV0YSBjcmVhdGVkIGEgbmV3IGhpZ2gtcXVhbGl0eSB0ZXN0IHNldCBvZiAyLDAwMCBwcm9tcHRzIGNvdmVyaW5nIDEyIGtleSB1c2UgY2FzZXMgKGUuZy4sIGNvZGluZywgcmVhc29uaW5nLCBjcmVhdGl2ZSB3cml0aW5nLCBpbnN0cnVjdGlvbiBmb2xsb3dpbmcpLiBUaGlzIHNldCBpcyB1c2VkIGZvciBodW1hbiBldmFsdWF0aW9uIHRvIGFzc2VzcyBwZXJmb3JtYW5jZSBvbiByZWFsLXdvcmxkLCBudWFuY2VkIHRhc2tzLiBcblxuIyMjICoqRXZhbHVhdGlvbiBEYXRhc2V0KipcblxuKipMaW5rOioqIFVuZGlzY2xvc2VkXG5cbioqRGF0YSBDb2xsZWN0aW9uIE1ldGhvZDoqKiBIeWJyaWQ6IEF1dG9tYXRlZCwgSHVtYW4sIFN5bnRoZXRpY1xuXG4qKkxhYmVsaW5nIE1ldGhvZDoqKiBIeWJyaWQ6IEh1bWFuLCBBdXRvbWF0ZWRcblxuKipQcm9wZXJ0aWVzOioqIFxuXG5UaGUgZXZhbHVhdGlvbiBkYXRhc2V0cyBhcmUgZGl2ZXJzZSBhbmQgdGVzdCBhIHdpZGUgc3BlY3RydW0gb2YgY2FwYWJpbGl0aWVzLiBNTUxVIG1lYXN1cmVzIGJyb2FkIG11bHRpdGFzayBrbm93bGVkZ2UuIEdQUUEgYXNzZXNzZXMgYWR2YW5jZWQgcmVhc29uaW5nIHdpdGggZGlmZmljdWx0LCBleHBlcnQtbGV2ZWwgcXVlc3Rpb25zLiBIdW1hbkV2YWwgYW5kIE1BVEggc3BlY2lmaWNhbGx5IHRlc3QgY29kZSBnZW5lcmF0aW9uIGFuZCBtYXRoZW1hdGljYWwgcmVhc29uaW5nIGFiaWxpdGllcywgcmVzcGVjdGl2ZWx5LiBNZXRhIGFsc28gdXRpbGl6ZXMgYSBsYXJnZSwgcHJpdmF0ZSwgaHVtYW4tYW5ub3RhdGVkIGV2YWx1YXRpb24gc2V0IGRlc2lnbmVkIHRvIGFzc2VzcyBtb2RlbCBwZXJmb3JtYW5jZSBpbiByZWFsLXdvcmxkLCBudWFuY2VkIHNjZW5hcmlvcy4gXG5cbioqQmFzZSBwcmV0cmFpbmVkIG1vZGVscyoqXG5cbnwgQ2F0ZWdvcnkgfCBCZW5jaG1hcmsgfCBcXCMgU2hvdHMgfCBNZXRyaWMgfCBMbGFtYSAzIDhCIHwgTGxhbWEgMy4xIDhCIHwgTGxhbWEgMyA3MEIgfCBMbGFtYSAzLjEgNzBCIHwgTGxhbWEgMy4xIDQwNUIgfFxufCA6LS0tLSB8IDotLS0tIHwgOi0tLS0gfCA6LS0tLSB8IDotLS0tIHwgOi0tLS0gfCA6LS0tLSB8IDotLS0tIHwgOi0tLS0gfFxufCBHZW5lcmFsIHwgTU1MVSB8IDUgfCBtYWNyb1xcX2F2Zy9hY2NcXF9jaGFyIHwgNjYuNyB8IDY2LjcgfCA3OS41IHwgNzkuMyB8IDg1LjIgfFxufCAgfCBNTUxVLVBybyAoQ29UKSB8IDUgfCBtYWNyb1xcX2F2Zy9hY2NcXF9jaGFyIHwgMzYuMiB8IDM3LjEgfCA1NS4wIHwgNTMuOCB8IDYxLjYgfFxufCAgfCBBR0lFdmFsIEVuZ2xpc2ggfCAzLTUgfCBhdmVyYWdlL2FjY1xcX2NoYXIgfCA0Ny4xIHwgNDcuOCB8IDYzLjAgfCA2NC42IHwgNzEuNiB8XG58ICB8IENvbW1vblNlbnNlUUEgfCA3IHwgYWNjXFxfY2hhciB8IDcyLjYgfCA3NS4wIHwgODMuOCB8IDg0LjEgfCA4NS44IHxcbnwgIHwgV2lub2dyYW5kZSB8IDUgfCBhY2NcXF9jaGFyIHwgXFwtIHwgNjAuNSB8IFxcLSB8IDgzLjMgfCA4Ni43IHxcbnwgIHwgQklHLUJlbmNoIEhhcmQgKENvVCkgfCAzIHwgYXZlcmFnZS9lbSB8IDYxLjEgfCA2NC4yIHwgODEuMyB8IDgxLjYgfCA4NS45IHxcbnwgIHwgQVJDLUNoYWxsZW5nZSB8IDI1IHwgYWNjXFxfY2hhciB8IDc5LjQgfCA3OS43IHwgOTMuMSB8IDkyLjkgfCA5Ni4xIHxcbnwgS25vd2xlZGdlIHJlYXNvbmluZyB8IFRyaXZpYVFBLVdpa2kgfCA1IHwgZW0gfCA3OC41IHwgNzcuNiB8IDg5LjcgfCA4OS44IHwgOTEuOCB8XG58IFJlYWRpbmcgY29tcHJlaGVuc2lvbiB8IFNRdUFEIHwgMSB8IGVtIHwgNzYuNCB8IDc3LjAgfCA4NS42IHwgODEuOCB8IDg5LjMgfFxufCAgfCBRdUFDIChGMSkgfCAxIHwgZjEgfCA0NC40IHwgNDQuOSB8IDUxLjEgfCA1MS4xIHwgNTMuNiB8XG58ICB8IEJvb2xRIHwgMCB8IGFjY1xcX2NoYXIgfCA3NS43IHwgNzUuMCB8IDc5LjAgfCA3OS40IHwgODAuMCB8XG58ICB8IERST1AgKEYxKSB8IDMgfCBmMSB8IDU4LjQgfCA1OS41IHwgNzkuNyB8IDc5LjYgfCA4NC44IHxcblxuKipJbnN0cnVjdGlvbiB0dW5lZCBtb2RlbHMqKlxuXG58IENhdGVnb3J5IHwgQmVuY2htYXJrIHwgXFwjIFNob3RzIHwgTWV0cmljIHwgTGxhbWEgMyA4QiBJbnN0cnVjdCB8IExsYW1hIDMuMSA4QiBJbnN0cnVjdCB8IExsYW1hIDMgNzBCIEluc3RydWN0IHwgTGxhbWEgMy4xIDcwQiBJbnN0cnVjdCB8IExsYW1hIDMuMSA0MDVCIEluc3RydWN0IHxcbnwgOi0tLS0gfCA6LS0tLSB8IDotLS0tIHwgOi0tLS0gfCA6LS0tLSB8IDotLS0tIHwgOi0tLS0gfCA6LS0tLSB8IDotLS0tIHxcbnwgR2VuZXJhbCB8IE1NTFUgfCA1IHwgbWFjcm9cXF9hdmcvYWNjIHwgNjguNSB8IDY5LjQgfCA4Mi4wIHwgODMuNiB8IDg3LjMgfFxufCAgfCBNTUxVIChDb1QpIHwgMCB8IG1hY3JvXFxfYXZnL2FjYyB8IDY1LjMgfCA3My4wIHwgODAuOSB8IDg2LjAgfCA4OC42IHxcbnwgIHwgTU1MVS1Qcm8gKENvVCkgfCA1IHwgbWljcm9cXF9hdmcvYWNjXFxfY2hhciB8IDQ1LjUgfCA0OC4zIHwgNjMuNCB8IDY2LjQgfCA3My4zIHxcbnwgIHwgSUZFdmFsIHwgIHwgIHwgNzYuOCB8IDgwLjQgfCA4Mi45IHwgODcuNSB8IDg4LjYgfFxufCBSZWFzb25pbmcgfCBBUkMtQyB8IDAgfCBhY2MgfCA4Mi40IHwgODMuNCB8IDk0LjQgfCA5NC44IHwgOTYuOSB8XG58ICB8IEdQUUEgfCAwIHwgZW0gfCAzNC42IHwgMzAuNCB8IDM5LjUgfCA0Ni43IHwgNTAuNyB8XG58IENvZGUgfCBIdW1hbkV2YWwgfCAwIHwgcGFzc0AxIHwgNjAuNCB8IDcyLjYgfCA4MS43IHwgODAuNSB8IDg5LjAgfFxufCAgfCBNQlBQIFxcKysgYmFzZSB2ZXJzaW9uIHwgMCB8IHBhc3NAMSB8IDcwLjYgfCA3Mi44IHwgODIuNSB8IDg2LjAgfCA4OC42IHxcbnwgIHwgTXVsdGlwbC1FIEh1bWFuRXZhbCB8IDAgfCBwYXNzQDEgfCBcXC0gfCA1MC44IHwgXFwtIHwgNjUuNSB8IDc1LjIgfFxufCAgfCBNdWx0aXBsLUUgTUJQUCB8IDAgfCBwYXNzQDEgfCBcXC0gfCA1Mi40IHwgXFwtIHwgNjIuMCB8IDY1LjcgfFxufCBNYXRoIHwgR1NNLThLIChDb1QpIHwgOCB8IGVtXFxfbWFqMUAxIHwgODAuNiB8IDg0LjUgfCA5My4wIHwgOTUuMSB8IDk2LjggfFxufCAgfCBNQVRIIChDb1QpIHwgMCB8IGZpbmFsXFxfZW0gfCAyOS4xIHwgNTEuOSB8IDUxLjAgfCA2OC4wIHwgNzMuOCB8XG58IFRvb2wgVXNlIHwgQVBJLUJhbmsgfCAwIHwgYWNjIHwgNDguMyB8IDgyLjYgfCA4NS4xIHwgOTAuMCB8IDkyLjAgfFxufCAgfCBCRkNMIHwgMCB8IGFjYyB8IDYwLjMgfCA3Ni4xIHwgODMuMCB8IDg0LjggfCA4OC41IHxcbnwgIHwgR29yaWxsYSBCZW5jaG1hcmsgQVBJIEJlbmNoIHwgMCB8IGFjYyB8IDEuNyB8IDguMiB8IDE0LjcgfCAyOS43IHwgMzUuMyB8XG58ICB8IE5leHVzICgwLXNob3QpIHwgMCB8IG1hY3JvXFxfYXZnL2FjYyB8IDE4LjEgfCAzOC41IHwgNDcuOCB8IDU2LjcgfCA1OC43IHxcbnwgTXVsdGlsaW5ndWFsIHwgTXVsdGlsaW5ndWFsIE1HU00gKENvVCkgfCAwIHwgZW0gfCBcXC0gfCA2OC45IHwgXFwtIHwgODYuOSB8IDkxLjYgfFxuXG4qKk11bHRpbGluZ3VhbCBiZW5jaG1hcmtzKipcblxufCBDYXRlZ29yeSB8IEJlbmNobWFyayB8IExhbmd1YWdlIHwgTGxhbWEgMy4xIDhCIHwgTGxhbWEgMy4xIDcwQiB8IExsYW1hIDMuMSA0MDVCIHxcbnwgOi0tLS0gfCA6LS0tLSB8IDotLS0tIHwgOi0tLS0gfCA6LS0tLSB8IDotLS0tIHxcbnwgR2VuZXJhbCB8IE1NTFUgKDUtc2hvdCwgbWFjcm9cXF9hdmcvYWNjKSB8IFBvcnR1Z3Vlc2UgfCA2Mi4xMiB8IDgwLjEzIHwgODQuOTUgfFxufCAgfCAgfCBTcGFuaXNoIHwgNjIuNDUgfCA4MC4wNSB8IDg1LjA4IHxcbnwgIHwgIHwgSXRhbGlhbiB8IDYxLjYzIHwgODAuNCB8IDg1LjA0IHxcbnwgIHwgIHwgR2VybWFuIHwgNjAuNTkgfCA3OS4yNyB8IDg0LjM2IHxcbnwgIHwgIHwgRnJlbmNoIHwgNjIuMzQgfCA3OS44MiB8IDg0LjY2IHxcbnwgIHwgIHwgSGluZGkgfCA1MC44OCB8IDc0LjUyIHwgODAuMzEgfFxufCAgfCAgfCBUaGFpIHwgNTAuMzIgfCA3Mi45NSB8IDc4LjIxIHxcblxuIyMgKipUZWNobmljYWwgTGltaXRhdGlvbnMqKiBcblxuVGVzdGluZyBjb25kdWN0ZWQgdG8gZGF0ZSBoYXMgbm90IGNvdmVyZWQsIG5vciBjb3VsZCBpdCBjb3ZlciwgYWxsIHNjZW5hcmlvcy4gRm9yIHRoZXNlIHJlYXNvbnMsIGFzIHdpdGggYWxsIExMTXMsIHRoZSBtb2RlbCdzIHBvdGVudGlhbCBvdXRwdXRzIGNhbm5vdCBiZSBwcmVkaWN0ZWQgaW4gYWR2YW5jZSwgYW5kIHRoZSBtb2RlbCBtYXkgaW4gc29tZSBpbnN0YW5jZXMgcHJvZHVjZSBpbmFjY3VyYXRlLCBiaWFzZWQgb3Igb3RoZXIgb2JqZWN0aW9uYWJsZSByZXNwb25zZXMgdG8gdXNlciBwcm9tcHRzLiBUaGVyZWZvcmUsIGJlZm9yZSBkZXBsb3lpbmcgdGhpcyBtb2RlbCBpbiBhbnkgYXBwbGljYXRpb25zLCBkZXZlbG9wZXJzIHNob3VsZCBwZXJmb3JtIHNhZmV0eSB0ZXN0aW5nIGFuZCB0dW5pbmcgdGFpbG9yZWQgdG8gdGhlaXIgc3BlY2lmaWMgYXBwbGljYXRpb25zLiBQbGVhc2UgcmVmZXIgdG8gYXZhaWxhYmxlIHJlc291cmNlcyBpbmNsdWRpbmcgdGhlIFtSZXNwb25zaWJsZSBVc2UgR3VpZGVdKGh0dHBzOi8vbGxhbWEubWV0YS5jb20vcmVzcG9uc2libGUtdXNlLWd1aWRlKSwgW1RydXN0IGFuZCBTYWZldHldKGh0dHBzOi8vbGxhbWEubWV0YS5jb20vdHJ1c3QtYW5kLXNhZmV0eS8pIHNvbHV0aW9ucywgYW5kIG90aGVyIFtyZXNvdXJjZXNdKGh0dHBzOi8vbGxhbWEubWV0YS5jb20vZG9jcy9nZXQtc3RhcnRlZC8pIHRvIGxlYXJuIG1vcmUgYWJvdXQgcmVzcG9uc2libGUgZGV2ZWxvcG1lbnQuIFxuXG4jIyAqKkluZmVyZW5jZToqKlxuXG4qKkFjY2VsZXJhdGlvbiBFbmdpbmU6KiogdkxMTSwgVGVuc29yUlQgXG5cbioqVGVzdCBIYXJkd2FyZToqKiBcblxuICBCMjAwIFNYTSAgIFxuICBIMjAwIFNYTSAgXG4gIEgxMDAgU1hNICBcbiAgQTEwMCBTWE0gODBHQiAgXG4gIEExMDAgU1hNIDQwR0IgIFxuICBMNDBTIFBDSWUgIFxuICBBMTBHICBcbiAgSDEwMCBOVkwgIFxuICBIMjAwIE5WTCAgXG4gIEdIMjAwIDk2R0IgIFxuICBHQjIwMCBOVkw3MiAgIFxuICBHSDIwMCBOVkwyICAgICBcbiAgUlRYIDUwOTAgIFxuICBSVFggNDA5MCAgXG4gIFJUWCA2MDAwIEFkYVxuXG4jIyAqKkV0aGljYWwgQ29uc2lkZXJhdGlvbnM6KipcblxuTlZJRElBIGJlbGlldmVzIFRydXN0d29ydGh5IEFJIGlzIGEgc2hhcmVkIHJlc3BvbnNpYmlsaXR5IGFuZCB3ZSBoYXZlIGVzdGFibGlzaGVkIHBvbGljaWVzIGFuZCBwcmFjdGljZXMgdG8gZW5hYmxlIGRldmVsb3BtZW50IGZvciBhIHdpZGUgYXJyYXkgb2YgQUkgYXBwbGljYXRpb25zLiBXaGVuIGRvd25sb2FkZWQgb3IgdXNlZCBpbiBhY2NvcmRhbmNlIHdpdGggb3VyIHRlcm1zIG9mIHNlcnZpY2UsIGRldmVsb3BlcnMgc2hvdWxkIHdvcmsgd2l0aCB0aGVpciBpbnRlcm5hbCBtb2RlbCB0ZWFtIHRvIGVuc3VyZSB0aGlzIG1vZGVsIG1lZXRzIHJlcXVpcmVtZW50cyBmb3IgdGhlIHJlbGV2YW50IGluZHVzdHJ5IGFuZCB1c2UgY2FzZSBhbmQgYWRkcmVzc2VzIHVuZm9yZXNlZW4gcHJvZHVjdCBtaXN1c2UuIFBsZWFzZSByZXBvcnQgc2VjdXJpdHkgdnVsbmVyYWJpbGl0aWVzIG9yIE5WSURJQSBBSSBDb25jZXJucyBbaGVyZV0oaHR0cHM6Ly93d3cubnZpZGlhLmNvbS9lbi11cy9zdXBwb3J0L3N1Ym1pdC1zZWN1cml0eS12dWxuZXJhYmlsaXR5LykuXG5cbllvdSBhcmUgcmVzcG9uc2libGUgZm9yIGVuc3VyaW5nIHRoYXQgeW91ciB1c2Ugb2YgTlZJRElBIHByb3ZpZGVkIG1vZGVscyBjb21wbGllcyB3aXRoIGFsbCBhcHBsaWNhYmxlIGxhd3MuIiwKICAgICJkaXNwbGF5TmFtZSI6ICJMbGFtYS0zLjEtNzBiLWluc3RydWN0IiwKICAgICJleHBsYWluYWJpbGl0eSI6ICIiLAogICAgImZyYW1ld29yayI6ICJPdGhlciIsCiAgICAiaGFzUGxheWdyb3VuZCI6IGZhbHNlLAogICAgImhhc1NpZ25lZFZlcnNpb24iOiB0cnVlLAogICAgImlzUGxheWdyb3VuZEVuYWJsZWQiOiBmYWxzZSwKICAgICJpc1B1YmxpYyI6IGZhbHNlLAogICAgImlzUmVhZE9ubHkiOiB0cnVlLAogICAgImxhYmVscyI6IFsKICAgICAgICAiTGxhbWEzLjEiLAogICAgICAgICJMbGFtYTMuMS03MGItaW5zdHJ1Y3QiLAogICAgICAgICJOSU0iLAogICAgICAgICJOU1BFQ1QtN1MzRi1RRkc4IiwKICAgICAgICAibnZhaWU6bW9kZWw6bnZhaWVfc3VwcG9ydGVkIiwKICAgICAgICAibnZpZGlhX25pbTptb2RlbDpuaW1tY3JvX252aWRpYV9uaW0iLAogICAgICAgICJwcm9kdWN0TmFtZXM6bmltLWRldiIsCiAgICAgICAgInByb2R1Y3ROYW1lczpudi1haS1lbnRlcnByaXNlIgogICAgXSwKICAgICJsYXRlc3RWZXJzaW9uSWRTdHIiOiAicnR4NjAwMC1ibGFja3dlbGwtc3Z4OC1sYXRlbmN5LWJmMTYtYnhpYWdoNGpnZyIsCiAgICAibGF0ZXN0VmVyc2lvblNpemVJbkJ5dGVzIjogMTU3MzU3MjY3OTI3LAogICAgImxvZ28iOiAiaHR0cHM6Ly9hc3NldHMubmdjLm52aWRpYS5jb20vcHJvZHVjdHMvYXBpLWNhdGFsb2cvaW1hZ2VzL2xsYW1hLTNfMS03MGItaW5zdHJ1Y3QuanBnIiwKICAgICJtb2RlbEZvcm1hdCI6ICJTYXZlZE1vZGVsIiwKICAgICJuYW1lIjogImxsYW1hLTMuMS03MGItaW5zdHJ1Y3QiLAogICAgIm9yZ05hbWUiOiAibmltIiwKICAgICJwcmVjaXNpb24iOiAiT1RIRVIiLAogICAgInByaXZhY3kiOiAiIiwKICAgICJwcm9kdWN0TmFtZXMiOiBbCiAgICAgICAgIm5pbS1kZXYiLAogICAgICAgICJudi1haS1lbnRlcnByaXNlIgogICAgXSwKICAgICJwdWJsaWNEYXRhc2V0VXNlZCI6IHt9LAogICAgInB1Ymxpc2hlciI6ICJNZXRhIiwKICAgICJzYWZldHlBbmRTZWN1cml0eSI6ICIiLAogICAgInNob3J0RGVzY3JpcHRpb24iOiAiVGhlIE1ldGEgTGxhbWEgMy4xIGNvbGxlY3Rpb24gb2YgbXVsdGlsaW5ndWFsIGxhcmdlIGxhbmd1YWdlIG1vZGVscyAoTExNcykgaXMgYSBjb2xsZWN0aW9uIG9mIHByZXRyYWluZWQgYW5kIGluc3RydWN0aW9uIHR1bmVkIGdlbmVyYXRpdmUgbW9kZWxzIGluIDhCLCA3MEIgYW5kIDQwNUIgc2l6ZXMgKHRleHQgaW4vdGV4dCBvdXQpLiIsCiAgICAidGVhbU5hbWUiOiAibWV0YSIsCiAgICAidXBkYXRlZERhdGUiOiAiMjAyNS0xMC0xNVQxNzo0OToxNS42MDVaIgp9
     source:
@@ -1616,6 +1857,315 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: VLLM
+    - profileId: nim/meta/llama-3.1-70b-instruct-pb25h2:1d54af340dc8906a2d21146191a9c184c35e47bd-rtx6000_blackwell_sv-tp2__3
+      framework: VLLM
+      displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx2 BF16
+      ngcMetadata:
+        39194b5f5858f2dde376844651af70e4471874a29935142320b972a2e3ca0ac5:
+          model: meta/llama-3.1-70b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'true'
+            feat_lora_max_rank: '32'
+            llm_engine: vllm
+            nim_workspace_hash_v1: 299821baf3058c03febd8fbfe6422d1342d72bee844f4d66ca27c24a3b190c0d
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 263GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.1-70b-instruct-pb25h2:1d54af340dc8906a2d21146191a9c184c35e47bd-rtx6000_blackwell_sv-tp2
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx2 FP8 Throughput
+      ngcMetadata:
+        bc57e25851a04ff1f855d632d2f656c8eb1a137e55eba2063adcb8ce1116069d:
+          model: meta/llama-3.1-70b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 43974cb445b2cc0a952d77e6a01d557c0fe4f2a3cc1c35796a1043c57518d3cf
+            number_of_gpus: '2'
+            pp: '1'
+            precision: fp8
+            profile: throughput
+            tp: '2'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: THROUGHPUT
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 263GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/meta/llama-3.1-70b-instruct-pb25h2:1d54af340dc8906a2d21146191a9c184c35e47bd-rtx6000_blackwell_sv-tp2__2
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx2 NVFP4 Throughput
+      ngcMetadata:
+        cab042186e90569e93c02348e34628537983e52ab710d3a4fdf42fc9fa4c569b:
+          model: meta/llama-3.1-70b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 6e54117bf7b0c8b928a004a7b02ae040230bdf0fb2670a5499a6b86de772bf59
+            number_of_gpus: '2'
+            pp: '1'
+            precision: nvfp4
+            profile: throughput
+            tp: '2'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: THROUGHPUT
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 263GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/meta/llama-3.1-70b-instruct-pb25h2:1d54af340dc8906a2d21146191a9c184c35e47bd-rtx6000_blackwell_sv-tp4__4
+      framework: VLLM
+      displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx4 BF16
+      ngcMetadata:
+        006abfcad3d12cfc6571d2e55f09a58957a0e3a5cd39c2df8c10e78f4ce10978:
+          model: meta/llama-3.1-70b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'true'
+            feat_lora_max_rank: '32'
+            llm_engine: vllm
+            nim_workspace_hash_v1: 299821baf3058c03febd8fbfe6422d1342d72bee844f4d66ca27c24a3b190c0d
+            pp: '1'
+            precision: bf16
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 263GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.1-70b-instruct-pb25h2:1d54af340dc8906a2d21146191a9c184c35e47bd-rtx6000_blackwell_sv-tp4__3
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx4 BF16 Throughput
+      ngcMetadata:
+        d917ec97b8b2584fe655c03e9152f33e1e1a485c90b8ced5098787bbcf196c7b:
+          model: meta/llama-3.1-70b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 8dc56a001e709d604284f145342698a414d54dc087b26f2fd39628b586819e8a
+            number_of_gpus: '4'
+            pp: '1'
+            precision: bf16
+            profile: throughput
+            tp: '4'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: THROUGHPUT
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 263GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/meta/llama-3.1-70b-instruct-pb25h2:1d54af340dc8906a2d21146191a9c184c35e47bd-rtx6000_blackwell_sv-tp4
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx4 FP8 Latency
+      ngcMetadata:
+        64bc125ba10664e556b2e4203702c2be799df905a26f16724dc5a5933dbad919:
+          model: meta/llama-3.1-70b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: eab1d9b2ac2520726f1218f41491e57157abcd21ba738a45b37deaa206384073
+            number_of_gpus: '4'
+            pp: '1'
+            precision: fp8
+            profile: latency
+            tp: '4'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: LATENCY
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 263GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/meta/llama-3.1-70b-instruct-pb25h2:1d54af340dc8906a2d21146191a9c184c35e47bd-rtx6000_blackwell_sv-tp4__2
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx4 NVFP4 Latency
+      ngcMetadata:
+        6a59fd6976eb5dc3d7c05f45c35f5aa5de00174b41957767c73c0034d91122e1:
+          model: meta/llama-3.1-70b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: bcb143d582f4a6c76551d735a1b403a716abe7d0bc20cf00d98d8c86ceb2dfe0
+            number_of_gpus: '4'
+            pp: '1'
+            precision: nvfp4
+            profile: latency
+            tp: '4'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: LATENCY
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 263GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/meta/llama-3.1-70b-instruct-pb25h2:1d54af340dc8906a2d21146191a9c184c35e47bd-rtx6000_blackwell_sv-tp8__2
+      framework: VLLM
+      displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx8 BF16
+      ngcMetadata:
+        3dcc4db7b5b522f47bf5c344038e6c8cad918617f954a0b751c9b7fcc5bb4d3f:
+          model: meta/llama-3.1-70b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'true'
+            feat_lora_max_rank: '32'
+            llm_engine: vllm
+            nim_workspace_hash_v1: 299821baf3058c03febd8fbfe6422d1342d72bee844f4d66ca27c24a3b190c0d
+            pp: '1'
+            precision: bf16
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 263GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.1-70b-instruct-pb25h2:1d54af340dc8906a2d21146191a9c184c35e47bd-rtx6000_blackwell_sv-tp8
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx8 BF16 Latency
+      ngcMetadata:
+        9eb233c7c0ee4da16616a30996ab9a65e9b5405708df3a19a06da04ac8a78495:
+          model: meta/llama-3.1-70b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: b84e4f23dec2af9146539c7f2865430fe42d7359aa1b3877c6beb286f0ef8558
+            number_of_gpus: '8'
+            pp: '1'
+            precision: bf16
+            profile: latency
+            tp: '8'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: LATENCY
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 263GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
   labels:
   - Llama
   - Meta

--- a/models/public/1.58.0/llama-3.3-instruct.yaml
+++ b/models/public/1.58.0/llama-3.3-instruct.yaml
@@ -2017,6 +2017,366 @@ models:
         value: 40GB
       - key: LLM ENGINE
         value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:bf16-6f6073b423013f6a7d4d9f39144961bfbfbc386b-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx1 BF16
+      ngcMetadata:
+        120f37d15ce21955b951e9acef346dcdcc0ebb17b9e09c1eef15e803a8b87665:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '174.0'
+            pp: '1'
+            precision: bf16
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 132GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:fp8-rxbjb-qrcq-tool-calling-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx1 FP8
+      ngcMetadata:
+        9dad49c0ef76f964e9295d8071045f0c6a2b52ffdc9cb11b8887adced9370554:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '111.0'
+            pp: '1'
+            precision: fp8
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 68GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:nvfp4-klvd4-nzbq-tool-calling-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx1 NVFP4
+      ngcMetadata:
+        13b2cabe93f6e3d81e056b10d747d4baffc8dc6708977963dbc02c378fe6e7fd:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '82.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 40GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:bf16-6f6073b423013f6a7d4d9f39144961bfbfbc386b-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx2 BF16
+      ngcMetadata:
+        314bf2e552c132bc56ed8503d5bd9f3c159abe5c9ca8a694e5e2081eb7c04649:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '89.0'
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 132GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:fp8-rxbjb-qrcq-tool-calling-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx2 FP8
+      ngcMetadata:
+        74dc099acf027ca44ed08bf7f182582f4f20bef8c9be768908a3a11f55a4803d:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '57.0'
+            pp: '1'
+            precision: fp8
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 68GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:nvfp4-klvd4-nzbq-tool-calling-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx2 NVFP4
+      ngcMetadata:
+        313ac0ae8b3d63007c5c3af22b90e3371d99332aff7a8d19162c0a5dfaaeade5:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '43.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 40GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:bf16-6f6073b423013f6a7d4d9f39144961bfbfbc386b-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx4 BF16
+      ngcMetadata:
+        128b00593671377d1f538c52b7c83d57f6d0bee57b32af3143368a7fe246afea:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '47.0'
+            pp: '1'
+            precision: bf16
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 132GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:fp8-rxbjb-qrcq-tool-calling-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx4 FP8
+      ngcMetadata:
+        16bb57d5dfa4bd677567955d1d4d6977b8bd1f9260139a5cce29ea7a7299b85f:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '31.0'
+            pp: '1'
+            precision: fp8
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 68GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:nvfp4-klvd4-nzbq-tool-calling-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx4 NVFP4
+      ngcMetadata:
+        b99f21d2c604622d124cbd2f922f523bd695690693f43b9dbd0937d43e43922c:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '24.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 40GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:bf16-6f6073b423013f6a7d4d9f39144961bfbfbc386b-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx8 BF16
+      ngcMetadata:
+        2914d34f4fa4833f89591ad3d5f92257d2167acb8ddb298a7ea0ad69629dbb16:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '25.0'
+            pp: '1'
+            precision: bf16
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 132GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:fp8-rxbjb-qrcq-tool-calling-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx8 FP8
+      ngcMetadata:
+        639213f8d80b20fddf456aa7c2e456b3d175b4043d1d5f1694a680757a25dad3:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '18.0'
+            pp: '1'
+            precision: fp8
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 68GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:nvfp4-klvd4-nzbq-tool-calling-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx8 NVFP4
+      ngcMetadata:
+        218de288d43ccaf69332f22c8826ead532723b7de3fbdd294b61051a3f1c83c6:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '15.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 40GB
+      - key: LLM ENGINE
+        value: VLLM
   labels:
   - Llama
   - Meta

--- a/models/public/1.58.0/llama-3.3-nemotron-super-49b.yaml
+++ b/models/public/1.58.0/llama-3.3-nemotron-super-49b.yaml
@@ -2081,6 +2081,366 @@ models:
         value: 29GB
       - key: LLM ENGINE
         value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-checkpoint-bf16-jetart-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx1 BF16
+      ngcMetadata:
+        8c3925b338d0bda8a4c95533c8c39e8ba9d38c2c7d4c687dd9fbc091186fccc1:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '120.0'
+            pp: '1'
+            precision: bf16
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 93GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:fp8-rmctserfba-tool-calling-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx1 FP8
+      ngcMetadata:
+        442b97776dbd568ef529479d866b000c7bd16b5f5d2422c213a0b3b1624c9281:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '76.0'
+            pp: '1'
+            precision: fp8
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 49GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:nvfp4-biyprhc44a-tool-calling-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx1 NVFP4
+      ngcMetadata:
+        50e2f862b5fe96cba5e45e2092d38845fa54104dcc03f4c0b2bdb23b4d05b6aa:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '56.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 29GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-checkpoint-bf16-jetart-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx2 BF16
+      ngcMetadata:
+        1146f49f84dff5dea09f5aa633cc70b92d7d972223d67878c841cd0fbccad4fb:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '62.0'
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 93GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:fp8-rmctserfba-tool-calling-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx2 FP8
+      ngcMetadata:
+        539eab4f3514e65516789d3bd11e4102aae5065a86e7cfb7688950bb456ce239:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '40.0'
+            pp: '1'
+            precision: fp8
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 49GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:nvfp4-biyprhc44a-tool-calling-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx2 NVFP4
+      ngcMetadata:
+        1952dc27de2122a4aadff950e4f7c6f7f383cdc63500c6bb483cc4d7fc930196:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '30.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 29GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-checkpoint-bf16-jetart-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx4 BF16
+      ngcMetadata:
+        6ffcc333dec0c7f62e8589513d5682d1268f47c552f6fc978080dd2c30389ba8:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '33.0'
+            pp: '1'
+            precision: bf16
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 93GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:fp8-rmctserfba-tool-calling-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx4 FP8
+      ngcMetadata:
+        18c1c9566d039d78881db55dd30907348afd73ff75f4e262aa1af824e320aa55:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '22.0'
+            pp: '1'
+            precision: fp8
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 49GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:nvfp4-biyprhc44a-tool-calling-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx4 NVFP4
+      ngcMetadata:
+        5122caf75c64b197b8d2170464500fd2aab69aa4d66c278629f7894271ca3ab9:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '17.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 29GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-checkpoint-bf16-jetart-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx8 BF16
+      ngcMetadata:
+        c7e34d09ffb6939d600faab0b43370ae4527cb008f2635464a53d9b46a368b27:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '19.0'
+            pp: '1'
+            precision: bf16
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 93GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:fp8-rmctserfba-tool-calling-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx8 FP8
+      ngcMetadata:
+        651f21dff2c1193dd7e606701ad1e18d5e35fe0cdc597f0b08a4af2609824af1:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '13.0'
+            pp: '1'
+            precision: fp8
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 49GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:nvfp4-biyprhc44a-tool-calling-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx8 NVFP4
+      ngcMetadata:
+        32dcea516a998a70f3069cdfbcc781de6c492c344cb38a29780f249fdb190e4d:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '11.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 29GB
+      - key: LLM ENGINE
+        value: VLLM
   labels:
   - Llama
   - Meta

--- a/models/public/1.58.0/minimax-m25.yaml
+++ b/models/public/1.58.0/minimax-m25.yaml
@@ -647,6 +647,108 @@ models:
         value: 215GB
       - key: LLM ENGINE
         value: SGLANG
+    - profileId: nim/minimax-ai/minimax-m25:hf-3040beaf-nim-rtx6000_blackwell_sv-tp2
+      framework: SGLang
+      displayName: Minimax M25 RTX6000_BLACKWELL_SVx2 FP8 Fallback
+      ngcMetadata:
+        2605f42cb4d0b90a89f44cfc23971278d95665b988d6d94b7e9b06326c21598f:
+          model: minimax-ai/minimax-m25
+          release: 1.7.1
+          tags:
+            ep: '1'
+            feat_lora: 'false'
+            llm_engine: sglang
+            pp: '1'
+            precision: fp8
+            profile: fallback
+            tp: '2'
+            vram: 300GiB
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: sglang
+      spec:
+      - key: PROFILE
+        value: FALLBACK
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 1.7.1
+      - key: DOWNLOAD SIZE
+        value: 215GB
+      - key: LLM ENGINE
+        value: SGLANG
+    - profileId: nim/minimax-ai/minimax-m25:hf-3040beaf-nim-rtx6000_blackwell_sv-tp4
+      framework: SGLang
+      displayName: Minimax M25 RTX6000_BLACKWELL_SVx4 FP8 Fallback
+      ngcMetadata:
+        15ebdb7833a74321359ccb332924083139a63677c5f16193f36f82874133b46a:
+          model: minimax-ai/minimax-m25
+          release: 1.7.1
+          tags:
+            ep: '1'
+            feat_lora: 'false'
+            llm_engine: sglang
+            pp: '1'
+            precision: fp8
+            profile: fallback
+            tp: '4'
+            vram: 300GiB
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: sglang
+      spec:
+      - key: PROFILE
+        value: FALLBACK
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 1.7.1
+      - key: DOWNLOAD SIZE
+        value: 215GB
+      - key: LLM ENGINE
+        value: SGLANG
+    - profileId: nim/minimax-ai/minimax-m25:hf-3040beaf-nim-rtx6000_blackwell_sv-tp8
+      framework: SGLang
+      displayName: Minimax M25 RTX6000_BLACKWELL_SVx8 FP8 Fallback
+      ngcMetadata:
+        ecc4f617f49bfa40d40c24eb3f0550233071bb62c387001be3155ee63c1a1ac0:
+          model: minimax-ai/minimax-m25
+          release: 1.7.1
+          tags:
+            ep: '8'
+            feat_lora: 'false'
+            llm_engine: sglang
+            pp: '1'
+            precision: fp8
+            profile: fallback
+            tp: '8'
+            vram: 300GiB
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: sglang
+      spec:
+      - key: PROFILE
+        value: FALLBACK
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 1.7.1
+      - key: DOWNLOAD SIZE
+        value: 215GB
+      - key: LLM ENGINE
+        value: SGLANG
   labels:
   - Multimodal
   - Minimax

--- a/models/public/1.58.0/mixtral-instruct.yaml
+++ b/models/public/1.58.0/mixtral-instruct.yaml
@@ -1303,6 +1303,274 @@ models:
         value: 87GB
       - key: LLM ENGINE
         value: VLLM
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v0-1:hf-a60832c-tool-use-v2-rtx6000_blackwell_sv__5
+      framework: VLLM
+      displayName: Mixtral 8x7b Instruct V0.1 RTX6000_BLACKWELL_SVx1 BF16
+      ngcMetadata:
+        61c1479f4e611effdbb853dbf3723f9f483f9261a16d05e67e8f122906bc9f05:
+          model: mistralai/mixtral-8x7b-instruct-v0.1
+          release: 1.12.0
+          tags:
+            feat_lora: 'true'
+            feat_lora_max_rank: '32'
+            llm_engine: vllm
+            nim_workspace_hash_v1: 1143086cd34eaa9e23556534ece80597734ec4653acf4ed38fc87f993b235371
+            pp: '1'
+            precision: bf16
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 1.12.0
+      - key: DOWNLOAD SIZE
+        value: 87GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v0-1:hf-a60832c-tool-use-v2-rtx6000_blackwell_sv
+      framework: TensorRT-LLM
+      displayName: Mixtral 8x7b Instruct V0.1 RTX6000_BLACKWELL_SVx1 BF16 Latency
+      ngcMetadata:
+        4de3615de4e17a52204267aa491eece5e2bf262b7e206e575629192e29905484:
+          model: mistralai/mixtral-8x7b-instruct-v0.1
+          release: 1.12.0
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 8746b88809968532d4e89e87a889301feb51db53963c629d5c8641f25cab7ef8
+            number_of_gpus: '1'
+            pp: '1'
+            precision: bf16
+            profile: latency
+            tp: '1'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: LATENCY
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.12.0
+      - key: DOWNLOAD SIZE
+        value: 87GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v0-1:hf-a60832c-tool-use-v2-rtx6000_blackwell_sv__4
+      framework: TensorRT-LLM
+      displayName: Mixtral 8x7b Instruct V0.1 RTX6000_BLACKWELL_SVx1 BF16 Throughput
+      ngcMetadata:
+        ffb72dbc582c757889db80e92ff451fbb41b7e2e282095011570664203059860:
+          model: mistralai/mixtral-8x7b-instruct-v0.1
+          release: 1.12.0
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: f3cadd31e5c7952a0e0240064b0a5d92eec6807465cc361c823f182252cd5e76
+            number_of_gpus: '1'
+            pp: '1'
+            precision: bf16
+            profile: throughput
+            tp: '1'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: THROUGHPUT
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.12.0
+      - key: DOWNLOAD SIZE
+        value: 87GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v0-1:hf-a60832c-tool-use-v2-rtx6000_blackwell_sv__3
+      framework: TensorRT-LLM
+      displayName: Mixtral 8x7b Instruct V0.1 RTX6000_BLACKWELL_SVx1 FP8 Latency
+      ngcMetadata:
+        eb79c173819637a1b1c609f26b732082affb7825871d5a6ba39eaa5ec516d18f:
+          model: mistralai/mixtral-8x7b-instruct-v0.1
+          release: 1.12.0
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 150c4a7f8276d0eeb355246dc21158e063c51d61015b972d77aed5189d9a62ec
+            number_of_gpus: '2'
+            pp: '1'
+            precision: fp8
+            profile: latency
+            tp: '1'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: LATENCY
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.12.0
+      - key: DOWNLOAD SIZE
+        value: 87GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v0-1:hf-a60832c-tool-use-v2-rtx6000_blackwell_sv__2
+      framework: TensorRT-LLM
+      displayName: Mixtral 8x7b Instruct V0.1 RTX6000_BLACKWELL_SVx1 FP8 Throughput
+      ngcMetadata:
+        9aa79b2cd14b16a6960827e7ec013a024d6236e6927ea63b276c7a4dc3b72964:
+          model: mistralai/mixtral-8x7b-instruct-v0.1
+          release: 1.12.0
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 1488c81eba6320033b07ded410dd4a688968e7233608309e434678488ab533f3
+            number_of_gpus: '2'
+            pp: '1'
+            precision: fp8
+            profile: throughput
+            tp: '1'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: THROUGHPUT
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.12.0
+      - key: DOWNLOAD SIZE
+        value: 87GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v0-1:hf-a60832c-tool-use-v2-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Mixtral 8x7b Instruct V0.1 RTX6000_BLACKWELL_SVx2 BF16
+      ngcMetadata:
+        3d73091fd6b66d810cbb9dd011fd842d2a1482a02258ff05f31cd9b00d91f3db:
+          model: mistralai/mixtral-8x7b-instruct-v0.1
+          release: 1.12.0
+          tags:
+            feat_lora: 'true'
+            feat_lora_max_rank: '32'
+            llm_engine: vllm
+            nim_workspace_hash_v1: 1143086cd34eaa9e23556534ece80597734ec4653acf4ed38fc87f993b235371
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 1.12.0
+      - key: DOWNLOAD SIZE
+        value: 87GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v0-1:hf-a60832c-tool-use-v2-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Mixtral 8x7b Instruct V0.1 RTX6000_BLACKWELL_SVx4 BF16
+      ngcMetadata:
+        dd8ce8a7f1a9025f007275f451a6e8b289f4e7b4fea07ac9664ad04b10d1e030:
+          model: mistralai/mixtral-8x7b-instruct-v0.1
+          release: 1.12.0
+          tags:
+            feat_lora: 'true'
+            feat_lora_max_rank: '32'
+            llm_engine: vllm
+            nim_workspace_hash_v1: 1143086cd34eaa9e23556534ece80597734ec4653acf4ed38fc87f993b235371
+            pp: '1'
+            precision: bf16
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 1.12.0
+      - key: DOWNLOAD SIZE
+        value: 87GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v0-1:hf-a60832c-tool-use-v2-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Mixtral 8x7b Instruct V0.1 RTX6000_BLACKWELL_SVx8 BF16
+      ngcMetadata:
+        b85a412ddf8383e654e9be84de4a2697b5096e5e0f9ca33b43bd1d61968552e8:
+          model: mistralai/mixtral-8x7b-instruct-v0.1
+          release: 1.12.0
+          tags:
+            feat_lora: 'true'
+            feat_lora_max_rank: '32'
+            llm_engine: vllm
+            nim_workspace_hash_v1: 1143086cd34eaa9e23556534ece80597734ec4653acf4ed38fc87f993b235371
+            pp: '1'
+            precision: bf16
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 1.12.0
+      - key: DOWNLOAD SIZE
+        value: 87GB
+      - key: LLM ENGINE
+        value: VLLM
   labels:
   - Mistral
   - Instruct

--- a/models/public/1.58.0/nemotron-3-nano.yaml
+++ b/models/public/1.58.0/nemotron-3-nano.yaml
@@ -2242,6 +2242,366 @@ models:
         value: 19GB
       - key: LLM ENGINE
         value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-52469ad-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx1 BF16
+      ngcMetadata:
+        352d88f8021d0ce396a61d10e929d1d4b45f75038b593595d0d92f80a398a032:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '63.0'
+            pp: '1'
+            precision: bf16
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 59GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-fp8-f25a17a-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx1 FP8
+      ngcMetadata:
+        8c91cce84b9b032ff4af489cb1a20395e223af35623010df9155390ab2284b7a:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '34.0'
+            pp: '1'
+            precision: fp8
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 31GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-nvfp4-bd1ffb1-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx1 NVFP4
+      ngcMetadata:
+        1fba9ecfcfb4cde28d4ce3fd55c40bca89a5a613e25e98f057befe6a7e99eada:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '21.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 19GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-52469ad-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx2 BF16
+      ngcMetadata:
+        004cb37f8eab12f30a94f183e0d9b0b1ab2858b17ab80de45138644c2e7007c1:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '34.0'
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 59GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-fp8-f25a17a-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx2 FP8
+      ngcMetadata:
+        49b534e3f90332a7af2d5c9932056e4482ce15fdfe19a596dfd9d662c63309ac:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '19.0'
+            pp: '1'
+            precision: fp8
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 31GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-nvfp4-bd1ffb1-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx2 NVFP4
+      ngcMetadata:
+        c7c492a20a88cb3ca9617f5de293ffabc6f382acd0e57daab70f8cf8f659231c:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '13.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 19GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-52469ad-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx4 BF16
+      ngcMetadata:
+        7c15a5935e32cad80808a37dbb3bb8de4e3eb8231eec55842866d4cfa11db426:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '19.0'
+            pp: '1'
+            precision: bf16
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 59GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-fp8-f25a17a-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx4 FP8
+      ngcMetadata:
+        9412ea9de9fdffb496984fc03b83a95f10e8d23cd019253f60283a7beeaf6a15:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '12.0'
+            pp: '1'
+            precision: fp8
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 31GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-nvfp4-bd1ffb1-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx4 NVFP4
+      ngcMetadata:
+        f49cfb0dd09f937b0515b57b5439c72694059c34af07281b41f1a83f438cbd20:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '9.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 19GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-52469ad-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx8 BF16
+      ngcMetadata:
+        2b28b859b310b857ac6cf272d42a2c984995ba0266f78725f4e26f73eb8ee5ba:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '12.0'
+            pp: '1'
+            precision: bf16
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 59GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-fp8-f25a17a-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx8 FP8
+      ngcMetadata:
+        12f8f7295a37cd1a9b6a3559b0d7449f6ca42ee7b5007de62208385ca1d75d0b:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '8.0'
+            pp: '1'
+            precision: fp8
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 31GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-nvfp4-bd1ffb1-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx8 NVFP4
+      ngcMetadata:
+        b5654c68ac107bc904007487ffe71ede6cb9a560e281929377b623d678f613b6:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '7.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 19GB
+      - key: LLM ENGINE
+        value: VLLM
   labels:
   - Chatbots
   - Virtual Assistants

--- a/models/public/1.58.0/nemotron-3-super-120b-a12b.yaml
+++ b/models/public/1.58.0/nemotron-3-super-120b-a12b.yaml
@@ -1698,6 +1698,366 @@ models:
         value: 75GB
       - key: LLM ENGINE
         value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-bf16-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx1 BF16
+      ngcMetadata:
+        9489f6f6de7ac7c9571b123c30b47a89e80b7881882d3124ab811388d7426ddb:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '237.0'
+            pp: '1'
+            precision: bf16
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 231GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-fp8-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx1 FP8
+      ngcMetadata:
+        5a1a326f51f49bebc8b6e374b1a71e242169e5eb88ef34ab781d0109c7eb7768:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '125.0'
+            pp: '1'
+            precision: fp8
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 120GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-nvfp4-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx1 NVFP4
+      ngcMetadata:
+        3b37a659a22c9390abe7b16aeb29c301c2e9c0e12e5b0fa76171681df31930e0:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '80.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 75GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-bf16-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx2 BF16
+      ngcMetadata:
+        37fe705735f5e860db323d70e43a6e31d1274ba4cf92401c8f3ff7e8a84f093c:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '121.0'
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 231GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-fp8-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx2 FP8
+      ngcMetadata:
+        57d42cc7d33914933427e7f8d8cb1773bc11e5c96826c92095820a8776e6a4f6:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '65.0'
+            pp: '1'
+            precision: fp8
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 120GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-nvfp4-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx2 NVFP4
+      ngcMetadata:
+        7cbcde87a4f6ae47e4ed6a12d236e84672f718a418b3eeb66b1249dec74c7109:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '42.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 75GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-bf16-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx4 BF16
+      ngcMetadata:
+        2f4c50e34aec6bc548c85c8341eda99896c990dd777efb2afc658ecec6f08e30:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '63.0'
+            pp: '1'
+            precision: bf16
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 231GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-fp8-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx4 FP8
+      ngcMetadata:
+        2ed42dc23f8e95f1fc0d2b50658a309344c3892bb99eea5c992679084a3ad52f:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '35.0'
+            pp: '1'
+            precision: fp8
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 120GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-nvfp4-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx4 NVFP4
+      ngcMetadata:
+        d08504a72861c984173b37188d78c7150a69570afdc56ca5a585edc9226115e2:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '24.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 75GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-bf16-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx8 BF16
+      ngcMetadata:
+        4a05267a2849aa326117676f55ae1a436e3a59f275d4c4e8ea8fed2190b5dea6:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '35.0'
+            pp: '1'
+            precision: bf16
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 231GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-fp8-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx8 FP8
+      ngcMetadata:
+        5791516f97ec7c748456aebee86f8bb9ce618dab40055a71ab40852c09787a4c:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '21.0'
+            pp: '1'
+            precision: fp8
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 120GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-nvfp4-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx8 NVFP4
+      ngcMetadata:
+        f8aa408323c38e25046ee87549a5847d666d02de45a029a40b34719dd3fb88c9:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '15.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 75GB
+      - key: LLM ENGINE
+        value: VLLM
   labels:
   - Chatbots
   - Virtual Assistants

--- a/models/public/1.58.0/nemotron-nano-12b-v2-vl.yaml
+++ b/models/public/1.58.0/nemotron-nano-12b-v2-vl.yaml
@@ -649,6 +649,66 @@ models:
         value: 15GB
       - key: LLM ENGINE
         value: VLLM
+    - profileId: nim/nvidia/nemotron-nano-12b-v2-vl:1.5.0-bf16-hf-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Nemotron Nano 12B V2 Vl RTX6000_BLACKWELL_SVx1 BF16
+      ngcMetadata:
+        06a217a1099a72e5d86a12a31fd39eaba9d7c00d3d311589557d2dc720b59358:
+          model: nvidia/nemotron-nano-12b-v2-vl
+          release: 1.5.0
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            nim_workspace_hash_v1: d943a0e2491f1abaae2e3c2532bc3b70535b0d8637d7b1aeed4e686f0e3e0f61
+            pp: '1'
+            precision: bf16
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 1.5.0
+      - key: DOWNLOAD SIZE
+        value: 25GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-nano-12b-v2-vl:1.5.0-bf16-hf-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Nemotron Nano 12B V2 Vl RTX6000_BLACKWELL_SVx2 BF16
+      ngcMetadata:
+        97aae95b218c9838fea29548ebaa771a922a8c9781c8450e542e323e2a76a937:
+          model: nvidia/nemotron-nano-12b-v2-vl
+          release: 1.5.0
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            nim_workspace_hash_v1: d943a0e2491f1abaae2e3c2532bc3b70535b0d8637d7b1aeed4e686f0e3e0f61
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 1.5.0
+      - key: DOWNLOAD SIZE
+        value: 25GB
+      - key: LLM ENGINE
+        value: VLLM
   labels:
   - Multimodal Vision Language Model
   - Visual Reasoning

--- a/models/public/1.58.0/nemotron-parse.yaml
+++ b/models/public/1.58.0/nemotron-parse.yaml
@@ -85,6 +85,70 @@ models:
         value: TENSORRT_LLM
       - key: TRTLLM BUILDABLE
         value: 'TRUE'
+    - profileId: nim/nvidia/nemotron-parse:hf-v5-b100
+      framework: TensorRT-LLM
+      displayName: Nemotron Parse B100x1 BF16
+      ngcMetadata:
+        a3d5f5727f27e898fc27658d0c11ff97a7de9edeff6c6065c2c838906f00dbd6:
+          model: nvidia/nemotron-parse
+          release: 1.5.0
+          tags:
+            llm_engine: tensorrt_llm
+            pp: '1'
+            precision: bf16
+            tllm_engine_config_json_str: '{"max_batch_size": 32}'
+            tp: '1'
+            trtllm_buildable: 'true'
+            gpu: B100
+            gpu_device: ''
+      modelFormat: trt-llm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: B100
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 1.5.0
+      - key: DOWNLOAD SIZE
+        value: 4GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+      - key: TRTLLM BUILDABLE
+        value: 'TRUE'
+    - profileId: nim/nvidia/nemotron-parse:hf-v5-b200
+      framework: TensorRT-LLM
+      displayName: Nemotron Parse B200x1 BF16
+      ngcMetadata:
+        a3d5f5727f27e898fc27658d0c11ff97a7de9edeff6c6065c2c838906f00dbd6:
+          model: nvidia/nemotron-parse
+          release: 1.5.0
+          tags:
+            llm_engine: tensorrt_llm
+            pp: '1'
+            precision: bf16
+            tllm_engine_config_json_str: '{"max_batch_size": 32}'
+            tp: '1'
+            trtllm_buildable: 'true'
+            gpu: B200
+            gpu_device: ''
+      modelFormat: trt-llm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: B200
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 1.5.0
+      - key: DOWNLOAD SIZE
+        value: 4GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+      - key: TRTLLM BUILDABLE
+        value: 'TRUE'
     - profileId: nim/nvidia/nemotron-parse:hf-v5-h100
       framework: TensorRT-LLM
       displayName: Nemotron Parse H100x1 BF16
@@ -179,6 +243,38 @@ models:
         value: 1
       - key: GPU DEVICE
         value: 26B9:10DE
+      - key: NIM VERSION
+        value: 1.5.0
+      - key: DOWNLOAD SIZE
+        value: 4GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+      - key: TRTLLM BUILDABLE
+        value: 'TRUE'
+    - profileId: nim/nvidia/nemotron-parse:hf-v5-rtx6000_blackwell_sv
+      framework: TensorRT-LLM
+      displayName: Nemotron Parse RTX6000_BLACKWELL_SVx1 BF16
+      ngcMetadata:
+        a3d5f5727f27e898fc27658d0c11ff97a7de9edeff6c6065c2c838906f00dbd6:
+          model: nvidia/nemotron-parse
+          release: 1.5.0
+          tags:
+            llm_engine: tensorrt_llm
+            pp: '1'
+            precision: bf16
+            tllm_engine_config_json_str: '{"max_batch_size": 32}'
+            tp: '1'
+            trtllm_buildable: 'true'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: trt-llm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
       - key: NIM VERSION
         value: 1.5.0
       - key: DOWNLOAD SIZE

--- a/models/public/1.58.0/starcoder-2.yaml
+++ b/models/public/1.58.0/starcoder-2.yaml
@@ -122,6 +122,138 @@ models:
         value: TENSORRT_LLM
       - key: TRTLLM BUILDABLE
         value: 'TRUE'
+    - profileId: nim/bigcode/starcoder2-7b:hf-bb9afde-b100
+      framework: TensorRT-LLM
+      displayName: Starcoder2 7B B100x1 BF16
+      ngcMetadata:
+        de71c59001bc42679b37ecddfd95ab7b759cfde4308071750dcf5e3558726c9b:
+          model: bigcode/starcoder2-7b
+          release: 1.15.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 43ab4fbb30e1beedda3de8df4244c9fc44fb8fbd8ba0ac23b028abf822bbf637
+            pp: '1'
+            precision: bf16
+            tp: '1'
+            trtllm_buildable: 'true'
+            gpu: B100
+            gpu_device: ''
+      modelFormat: trt-llm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: B100
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 1.15.3
+      - key: DOWNLOAD SIZE
+        value: 14GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+      - key: TRTLLM BUILDABLE
+        value: 'TRUE'
+    - profileId: nim/bigcode/starcoder2-7b:hf-bb9afde-b100-tp2
+      framework: TensorRT-LLM
+      displayName: Starcoder2 7B B100x2 BF16
+      ngcMetadata:
+        fe652f0f0ef911e255f1ff710d522d112ffda7856fe58824a9a5ef963960c909:
+          model: bigcode/starcoder2-7b
+          release: 1.15.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 43ab4fbb30e1beedda3de8df4244c9fc44fb8fbd8ba0ac23b028abf822bbf637
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            trtllm_buildable: 'true'
+            gpu: B100
+            gpu_device: ''
+      modelFormat: trt-llm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: B100
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 1.15.3
+      - key: DOWNLOAD SIZE
+        value: 14GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+      - key: TRTLLM BUILDABLE
+        value: 'TRUE'
+    - profileId: nim/bigcode/starcoder2-7b:hf-bb9afde-b200
+      framework: TensorRT-LLM
+      displayName: Starcoder2 7B B200x1 BF16
+      ngcMetadata:
+        de71c59001bc42679b37ecddfd95ab7b759cfde4308071750dcf5e3558726c9b:
+          model: bigcode/starcoder2-7b
+          release: 1.15.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 43ab4fbb30e1beedda3de8df4244c9fc44fb8fbd8ba0ac23b028abf822bbf637
+            pp: '1'
+            precision: bf16
+            tp: '1'
+            trtllm_buildable: 'true'
+            gpu: B200
+            gpu_device: ''
+      modelFormat: trt-llm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: B200
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 1.15.3
+      - key: DOWNLOAD SIZE
+        value: 14GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+      - key: TRTLLM BUILDABLE
+        value: 'TRUE'
+    - profileId: nim/bigcode/starcoder2-7b:hf-bb9afde-b200-tp2
+      framework: TensorRT-LLM
+      displayName: Starcoder2 7B B200x2 BF16
+      ngcMetadata:
+        fe652f0f0ef911e255f1ff710d522d112ffda7856fe58824a9a5ef963960c909:
+          model: bigcode/starcoder2-7b
+          release: 1.15.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 43ab4fbb30e1beedda3de8df4244c9fc44fb8fbd8ba0ac23b028abf822bbf637
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            trtllm_buildable: 'true'
+            gpu: B200
+            gpu_device: ''
+      modelFormat: trt-llm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: B200
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 1.15.3
+      - key: DOWNLOAD SIZE
+        value: 14GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+      - key: TRTLLM BUILDABLE
+        value: 'TRUE'
     - profileId: nim/bigcode/starcoder2-7b:hf-bb9afde-h100
       framework: TensorRT-LLM
       displayName: Starcoder2 7B H100x1 BF16
@@ -540,6 +672,72 @@ models:
         value: 2
       - key: GPU DEVICE
         value: 26B9:10DE
+      - key: NIM VERSION
+        value: 1.15.3
+      - key: DOWNLOAD SIZE
+        value: 14GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+      - key: TRTLLM BUILDABLE
+        value: 'TRUE'
+    - profileId: nim/bigcode/starcoder2-7b:hf-bb9afde-rtx6000_blackwell_sv
+      framework: TensorRT-LLM
+      displayName: Starcoder2 7B RTX6000_BLACKWELL_SVx1 BF16
+      ngcMetadata:
+        de71c59001bc42679b37ecddfd95ab7b759cfde4308071750dcf5e3558726c9b:
+          model: bigcode/starcoder2-7b
+          release: 1.15.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 43ab4fbb30e1beedda3de8df4244c9fc44fb8fbd8ba0ac23b028abf822bbf637
+            pp: '1'
+            precision: bf16
+            tp: '1'
+            trtllm_buildable: 'true'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: trt-llm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 1.15.3
+      - key: DOWNLOAD SIZE
+        value: 14GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+      - key: TRTLLM BUILDABLE
+        value: 'TRUE'
+    - profileId: nim/bigcode/starcoder2-7b:hf-bb9afde-rtx6000_blackwell_sv-tp2
+      framework: TensorRT-LLM
+      displayName: Starcoder2 7B RTX6000_BLACKWELL_SVx2 BF16
+      ngcMetadata:
+        fe652f0f0ef911e255f1ff710d522d112ffda7856fe58824a9a5ef963960c909:
+          model: bigcode/starcoder2-7b
+          release: 1.15.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 43ab4fbb30e1beedda3de8df4244c9fc44fb8fbd8ba0ac23b028abf822bbf637
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            trtllm_buildable: 'true'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: trt-llm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
       - key: NIM VERSION
         value: 1.15.3
       - key: DOWNLOAD SIZE

--- a/models/public/1.59.0/cosmos-reason2-8b.yaml
+++ b/models/public/1.59.0/cosmos-reason2-8b.yaml
@@ -534,6 +534,35 @@ models:
         value: 10GB
       - key: LLM ENGINE
         value: VLLM
+    - profileId: nim/nvidia/cosmos-reason2-8b:hf-0303-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Cosmos Reason2 8B RTX6000_BLACKWELL_SVx1 BF16
+      ngcMetadata:
+        438f4f3c69868f7755b07d0a0e03396f2c8862a570e4603572578785b137d1c3:
+          model: nvidia/cosmos-reason2-8b
+          release: '1.7.0'
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            nim_workspace_hash_v1: e905c7b3c8f807e05968ea232cda81e59f27545f1a24e07edad14d003935ee13
+            precision: bf16
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: '1.7.0'
+      - key: DOWNLOAD SIZE
+        value: 17GB
+      - key: LLM ENGINE
+        value: VLLM
   labels:
   - Multimodal
   - Vision-Language

--- a/models/public/1.59.0/gpt-oss.yaml
+++ b/models/public/1.59.0/gpt-oss.yaml
@@ -801,6 +801,126 @@ models:
         value: 13GB
       - key: LLM ENGINE
         value: VLLM
+    - profileId: nim/openai/gpt-oss-20b:hf-d666cf3-nim-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: GPT-OSS 20B RTX6000_BLACKWELL_SVx1 MXFP4
+      ngcMetadata:
+        66fb3113efd2aae1b0a3bfa2a375de5fe1cc1b557abac4eb271730482a26ae8e:
+          model: openai/gpt-oss-20b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            nim_workspace_hash_v1: bef4d428df8c3e67ebe56ba2050a0f50216e82c0172407b43c99c1f6befc9fc5
+            pp: '1'
+            precision: mxfp4
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: MXFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 13GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/openai/gpt-oss-20b:hf-d666cf3-nim-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: GPT-OSS 20B RTX6000_BLACKWELL_SVx2 MXFP4
+      ngcMetadata:
+        c3035169e189674226b284a07173f495b6ce13f2a06d5ea204f1e505c2fac2be:
+          model: openai/gpt-oss-20b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            nim_workspace_hash_v1: bef4d428df8c3e67ebe56ba2050a0f50216e82c0172407b43c99c1f6befc9fc5
+            pp: '1'
+            precision: mxfp4
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: MXFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 13GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/openai/gpt-oss-20b:hf-d666cf3-nim-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: GPT-OSS 20B RTX6000_BLACKWELL_SVx4 MXFP4
+      ngcMetadata:
+        653e98d21f9274306416d736519e1c0442d9dad9d8756ff1134cbededfd43323:
+          model: openai/gpt-oss-20b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            nim_workspace_hash_v1: bef4d428df8c3e67ebe56ba2050a0f50216e82c0172407b43c99c1f6befc9fc5
+            pp: '1'
+            precision: mxfp4
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: MXFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 13GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/openai/gpt-oss-20b:hf-d666cf3-nim-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: GPT-OSS 20B RTX6000_BLACKWELL_SVx8 MXFP4
+      ngcMetadata:
+        66b8ec445352535aa8c640435d6f7b00fb2cabb70f8d39fc371adb00322907df:
+          model: openai/gpt-oss-20b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            nim_workspace_hash_v1: bef4d428df8c3e67ebe56ba2050a0f50216e82c0172407b43c99c1f6befc9fc5
+            pp: '1'
+            precision: mxfp4
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: MXFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 13GB
+      - key: LLM ENGINE
+        value: VLLM
   - variantId: GPT-OSS 120B
     modelCard: ewogICAgImFjY2Vzc1R5cGUiOiAiTk9UX0xJU1RFRCIsCiAgICAiYXBwbGljYXRpb24iOiAiT3RoZXIiLAogICAgImJpYXMiOiAiIiwKICAgICJjYW5HdWVzdERvd25sb2FkIjogZmFsc2UsCiAgICAiY3JlYXRlZERhdGUiOiAiMjAyNS0wOC0wNVQxOTozNzowNi4zMzBaIiwKICAgICJkZXNjcmlwdGlvbiI6ICIjIEdQVCBPU1MgMTIwQiBPdmVydmlld1xuXG4jIyBEZXNjcmlwdGlvbjogPGJyPlxuT3BlbkFJIHJlbGVhc2VzIHRoZSBncHQtb3NzIGZhbWlseSBvZiBvcGVuLXdlaWdodCBtb2RlbHMgZGVzaWduZWQgZm9yIHBvd2VyZnVsIHJlYXNvbmluZywgYWdlbnRpYyB0YXNrcywgYW5kIHZlcnNhdGlsZSBkZXZlbG9wZXIgdXNlIGNhc2VzLiBUaGUgZmFtaWx5IGNvbnNpc3RzIG9mIHRoZTpcbi0gYGdwdC1vc3MtMTIwYmAgXHUyMDE0IGZvciBwcm9kdWN0aW9uLCBnZW5lcmFsIHB1cnBvc2UsIGhpZ2ggcmVhc29uaW5nIHVzZS1jYXNlcyB0aGF0IGZpdHMgaW50byBhIHNpbmdsZSBIMTAwIEdQVSAoMTE3QiBwYXJhbWV0ZXJzIHdpdGggNS4xQiBhY3RpdmUgcGFyYW1ldGVycylcbi0gYGdwdC1vc3MtMjBiYCBcdTIwMTQgZm9yIGxvd2VyIGxhdGVuY3ksIGFuZCBsb2NhbCBvciBzcGVjaWFsaXplZCB1c2UtY2FzZXMgKDIxQiBwYXJhbWV0ZXJzIHdpdGggMy42QiBhY3RpdmUgcGFyYW1ldGVycykuXG5cblRoZSBgZ3B0LW9zcy0xMjBiYCBtb2RlbCBpcyBhcmNoaXRlY3R1cmFsbHkgZGVzaWduZWQgYXMgYSBNaXh0dXJlLW9mLUV4cGVydHMgKE1vRSkgbW9kZWwuIFRoaXMgbW9kZWwgZmVhdHVyZXMgU3dpR0xVIGFjdGl2YXRpb25zIGFuZCBsZWFybmVkIGF0dGVudGlvbiBzaW5rcyB3aXRoaW4gaXRzIGFyY2hpdGVjdHVyZS4gSXQgZnVuY3Rpb25zIGFzIGEgcmVhc29uaW5nIG1vZGVsLCBzdXBwb3J0aW5nIGNhcGFiaWxpdGllcyBzdWNoIGFzIGNoYWluLW9mLXRob3VnaHQgcHJvY2Vzc2luZywgYWRqdXN0YWJsZSByZWFzb25pbmcgZWZmb3J0IGxldmVscywgaW5zdHJ1Y3Rpb24gZm9sbG93aW5nLCBhbmQgdG9vbCB1c2UuIFRoaXMgbW9kZWwgaXMgdGV4dC1vbmx5IGZvciBib3RoIGlucHV0IGFuZCBvdXRwdXQgbW9kYWxpdGllcywgZW5hYmxpbmcgZW50ZXJwcmlzZXMgYW5kIGdvdmVybm1lbnRzIHRvIGRlcGxveSBpdCBvbi1wcmVtaXNlcyBvciBpbiBwcml2YXRlIGNsb3VkIGVudmlyb25tZW50cyBmb3IgZW5oYW5jZWQgZGF0YSBzZWN1cml0eSBhbmQgcHJpdmFjeS5cblxuTW9kZWwgSGlnaGxpZ2h0czogIFxuLSAqKlBlcm1pc3NpdmUgQXBhY2hlIDIuMCBsaWNlbnNlOioqIEJ1aWxkIGZyZWVseSB3aXRob3V0IGNvcHlsZWZ0IHJlc3RyaWN0aW9ucyBvciBwYXRlbnQgcmlza1x1MjAxNGlkZWFsIGZvciBleHBlcmltZW50YXRpb24sIGN1c3RvbWl6YXRpb24sIGFuZCBjb21tZXJjaWFsIGRlcGxveW1lbnQuXG4tICoqQ29uZmlndXJhYmxlIHJlYXNvbmluZyBlZmZvcnQ6KiogRWFzaWx5IGFkanVzdCB0aGUgcmVhc29uaW5nIGVmZm9ydCAobG93LCBtZWRpdW0sIGhpZ2gpIGJhc2VkIG9uIHlvdXIgc3BlY2lmaWMgdXNlIGNhc2UgYW5kIGxhdGVuY3kgbmVlZHMuXG4tICoqRnVsbCBjaGFpbi1vZi10aG91Z2h0OioqIEdhaW4gY29tcGxldGUgYWNjZXNzIHRvIHRoZSBtb2RlbCdzIHJlYXNvbmluZyBwcm9jZXNzLCBmYWNpbGl0YXRpbmcgZWFzaWVyIGRlYnVnZ2luZyBhbmQgaW5jcmVhc2VkIHRydXN0IGluIG91dHB1dHMuIEl0J3Mgbm90IGludGVuZGVkIHRvIGJlIHNob3duIHRvIGVuZCB1c2Vycy5cbi0gKipGaW5lLXR1bmFibGU6KiogRnVsbHkgY3VzdG9taXplIG1vZGVscyB0byB5b3VyIHNwZWNpZmljIHVzZSBjYXNlIHRocm91Z2ggcGFyYW1ldGVyIGZpbmUtdHVuaW5nLlxuLSAqKkFnZW50aWMgY2FwYWJpbGl0aWVzOioqIFVzZSB0aGUgbW9kZWxzJyBuYXRpdmUgY2FwYWJpbGl0aWVzIGZvciBmdW5jdGlvbiBjYWxsaW5nLCB3ZWIgYnJvd3NpbmcsIHB5dGhvbiBjb2RlIGV4ZWN1dGlvbiwgYW5kIHN0cnVjdHVyZWQgb3V0cHV0cy5cblxuVGhpcyBtb2RlbCBpcyByZWFkeSBmb3IgY29tbWVyY2lhbC9ub24tY29tbWVyY2lhbCB1c2UuXG5cblxuIyMgVGhpcmQtUGFydHkgQ29tbXVuaXR5IENvbnNpZGVyYXRpb24gPGJyPlxuVGhpcyBtb2RlbCBpcyBub3Qgb3duZWQgb3IgZGV2ZWxvcGVkIGJ5IE5WSURJQS4gVGhpcyBtb2RlbCBoYXMgYmVlbiBkZXZlbG9wZWQgYW5kIGJ1aWx0IHRvIGEgdGhpcmQtcGFydHlcdTIwMTlzIHJlcXVpcmVtZW50cyBmb3IgdGhpcyBhcHBsaWNhdGlvbiBhbmQgdXNlIGNhc2U7IHNlZSBsaW5rIHRvIE5vbi1OVklESUEgW2dwdC1vc3MtMTIwYiBtb2RlbCBjYXJkXShodHRwczovL2h1Z2dpbmdmYWNlLmNvL29wZW5haS9ncHQtb3NzLTEyMGIpLlxuXG5cbiMjIyBMaWNlbnNlIGFuZCBUZXJtcyBvZiBVc2U6IDxicj5cbkdPVkVSTklORyBURVJNUzogVGhlIE5JTSBjb250YWluZXIgaXMgZ292ZXJuZWQgYnkgdGhlIFtOVklESUEgU29mdHdhcmUgTGljZW5zZSBBZ3JlZW1lbnRdKGF0IGh0dHBzOi8vd3d3Lm52aWRpYS5jb20vZW4tdXMvYWdyZWVtZW50cy9lbnRlcnByaXNlLXNvZnR3YXJlL252aWRpYS1zb2Z0d2FyZS1saWNlbnNlLWFncmVlbWVudC8pIGFuZCB0aGUgW1Byb2R1Y3QtU3BlY2lmaWMgVGVybXMgZm9yIE5WSURJQSBBSSBQcm9kdWN0c10oaHR0cHM6Ly93d3cubnZpZGlhLmNvbS9lbi11cy9hZ3JlZW1lbnRzL2VudGVycHJpc2Utc29mdHdhcmUvcHJvZHVjdC1zcGVjaWZpYy10ZXJtcy1mb3ItYWktcHJvZHVjdHMvKTsgYW5kIHRoZSB1c2Ugb2YgdGhpcyBtb2RlbCBpcyBnb3Zlcm5lZCBieSB0aGUgW05WSURJQSBDb21tdW5pdHkgTW9kZWwgTGljZW5zZSBBZ3JlZW1lbnRdKGh0dHBzOi8vd3d3Lm52aWRpYS5jb20vZW4tdXMvYWdyZWVtZW50cy9lbnRlcnByaXNlLXNvZnR3YXJlL252aWRpYS1jb21tdW5pdHktbW9kZWxzLWxpY2Vuc2UvKS5cbkFkZGl0aW9uYWwgSW5mb3JtYXRpb246IFtBcGFjaGUgTGljZW5zZSBWZXJzaW9uIDIuMF0oaHR0cHM6Ly93d3cuYXBhY2hlLm9yZy9saWNlbnNlcy9MSUNFTlNFLTIuMCkuXG5cbioqWW91IGFyZSByZXNwb25zaWJsZSBmb3IgZW5zdXJpbmcgdGhhdCB5b3VyIHVzZSBvZiBOVklESUEgcHJvdmlkZWQgbW9kZWxzIGNvbXBsaWVzIHdpdGggYWxsIGFwcGxpY2FibGUgbGF3cyoqXG5cbiMjIEdldCBIZWxwXG5cbiMjIyBFbnRlcnByaXNlIFN1cHBvcnRcblxuR2V0IGFjY2VzcyB0byBrbm93bGVkZ2UgYmFzZSBhcnRpY2xlcyBhbmQgc3VwcG9ydCBjYXNlcyBvciBbc3VibWl0IGEgdGlja2V0XShodHRwczovL3d3dy5udmlkaWEuY29tL2VuLXVzL2RhdGEtY2VudGVyL3Byb2R1Y3RzL2FpLWVudGVycHJpc2Utc3VpdGUvc3VwcG9ydC8pLlxuXG4jIyMgTlZJRElBIE5JTSBEb2N1bWVudGF0aW9uXG5cblZpc2l0IHRoZSBbTklNIENvbnRhaW5lciBMTE1dKGh0dHBzOi8vZG9jcy5udmlkaWEuY29tL25pbS9sYXJnZS1sYW5ndWFnZS1tb2RlbHMvbGF0ZXN0L2ludHJvZHVjdGlvbi5odG1sKSBwYWdlIGZvciByZWxlYXNlIGRvY3VtZW50YXRpb24sIGRlcGxveW1lbnQgZ3VpZGVzIGFuZCBtb3JlLlxuXG4jIyMgRGVwbG95bWVudCBHZW9ncmFwaHk6XG5HbG9iYWxcblxuIyMjIFVzZSBDYXNlOiA8YnI+XG5JbnRlbmRlZCBmb3IgdXNlIGFzIGEgcmVhc29uaW5nIG1vZGVsIHdpdGggZmVhdHVyZXMgbGlrZSBjaGFpbi1vZi10aG91Z2h0IGFuZCBhZGp1c3RhYmxlIHJlYXNvbmluZyBlZmZvcnQgbGV2ZWxzLiBJdCBzdXBwb3J0cyBpbnN0cnVjdGlvbiBmb2xsb3dpbmcgYW5kIHRvb2wgdXNlLCBvZmZlcmluZyB0cmFuc3BhcmVuY3ksIGN1c3RvbWl6YXRpb24sIGFuZCBkZXBsb3ltZW50IGZsZXhpYmlsaXR5IGZvciBkZXZlbG9wZXJzLCByZXNlYXJjaGVycywgYW5kIHN0YXJ0dXBzLiBBZGRpdGlvbmFsbHksIGl0IGVuYWJsZXMgZW50ZXJwcmlzZXMgYW5kIGdvdmVybm1lbnRzIHRvIGRlcGxveSBvbi1wcmVtaXNlcyBvciBpbiBwcml2YXRlIGNsb3VkcyB0byBlbnN1cmUgZGF0YSBzZWN1cml0eSBhbmQgcHJpdmFjeS5cblxuIyMjIFJlbGVhc2UgRGF0ZTogIDxicj5cbkJ1aWxkLk5WSURJQS5jb20gLSAwOC8wNS8yMDI1IHZpYSBbbGlua10oaHR0cHM6Ly9idWlsZC5udmlkaWEuY29tL29wZW5haS9ncHQtb3NzLTEyMGIpIDxicj4gXG5IdWdnaW5nIEZhY2UgLSAwOC8wNS8yMDI1IHZpYSBbbGlua10oaHR0cHM6Ly9odWdnaW5nZmFjZS5jby9vcGVuYWkvZ3B0LW9zcy0xMjBiKSA8YnI+XG5cbiMjIFJlZmVyZW5jZShzKTpcbi0gW09wZW5BSSBDb29rYm9va10oaHR0cHM6Ly9jb29rYm9vay5vcGVuYWkuY29tLylcbi0gW09wZW4gQUkgQ29vYmtib29rIC0tIFNlcnZpbmcgTW9kZWwgd2l0aCBUZW5zb3JSVC1MTE1dKGh0dHBzOi8vY29va2Jvb2sub3BlbmFpLmNvbS9hcnRpY2xlcy9ncHQtb3NzL3J1bi1udmlkaWEpXG5cblxuIyMgTW9kZWwgQXJjaGl0ZWN0dXJlOiA8YnI+IFxuKipBcmNoaXRlY3R1cmUgVHlwZToqKiBUcmFuc2Zvcm1lciA8YnI+XG4qKk5ldHdvcmsgQXJjaGl0ZWN0dXJlOioqIE1peHR1cmUtb2YtRXhwZXJ0cyAoTW9FKSA8YnI+XG4qKlRvdGFsIFBhcmFtZXRlcnM6KiogMTE3QiA8YnI+XG4qKkFjdGl2ZSBQYXJhbWV0ZXJzOioqIDUuN0IgPGJyPlxuKipWb2NhYnVsYXJ5IFNpemU6KiogMjAxLDA4OCA8YnI+XG5cblxuIyMgSW5wdXQ6IDxicj5cbioqSW5wdXQgVHlwZShzKToqKiBUZXh0IDxicj5cbioqSW5wdXQgRm9ybWF0KHMpOioqIFN0cmluZyA8YnI+XG4qKklucHV0IFBhcmFtZXRlcnM6KiogT25lIERpbWVuc2lvbmFsICgxRCkgPGJyPlxuKipPdGhlciBQcm9wZXJ0aWVzIFJlbGF0ZWQgdG8gSW5wdXQ6KiogVXNlcyBSb1BFIHdpdGggYSAxMjhrIGNvbnRleHQgbGVuZ3RoLCB3aXRoIGF0dGVudGlvbiBsYXllcnMgYWx0ZXJuYXRpbmcgYmV0d2VlbiBmdWxsIGNvbnRleHQgYW5kIGEgc2xpZGluZyAxMjgtdG9rZW4gd2luZG93LiBJbmNsdWRlcyBhIGxlYXJuZWQgYXR0ZW50aW9uIHNpbmsgcGVyLWhlYWQuIEVtcGxveXMgU3dpR0xVIGFjdGl2YXRpb25zIGluIHRoZSBNb0UgbGF5ZXJzLCBhbmQgdGhlIHJvdXRlciBwZXJmb3JtcyBhIFRvcC1LIG9wZXJhdGlvbiAoSz00KSBmb2xsb3dlZCBieSBhIFNpZ21vaWQgZnVuY3Rpb24uIEdFTU1zIGluIHRoZSBNb0UgaW5jbHVkZSBhIHBlci1leHBlcnQgYmlhcy4gVXRpbGl6ZXMgdGlrdG9rZW4gZm9yIHRva2VuaXphdGlvbi4gSW5wdXQgQ29udGV4dCBMZW5ndGggKElTTCk6IDEyODAwMCA8YnI+XG5cbiMjIE91dHB1dDogPGJyPlxuKipPdXRwdXQgVHlwZShzKToqKiBUZXh0IDxicj5cbioqT3V0cHV0IEZvcm1hdDoqKiBTdHJpbmcgPGJyPlxuKipPdXRwdXQgUGFyYW1ldGVyczoqKiBPbmUgRGltZW5zaW9uYWwgKDFEKSA8YnI+XG4qKk90aGVyIFByb3BlcnRpZXMgUmVsYXRlZCB0byBPdXRwdXQ6KiogVGhlIG1vZGVsIGlzIGRlc2lnbmVkIHRvIGJlIGNvbXBhdGlibGUgd2l0aCB0aGUgT3BlbkFJIFJlc3BvbnNlcyBBUEkgYW5kIHN1cHBvcnRzIFN0cnVjdHVyZWQgT3V0cHV0LiA8YnI+IFxuXG5PdXIgQUkgbW9kZWxzIGFyZSBkZXNpZ25lZCBhbmQvb3Igb3B0aW1pemVkIHRvIHJ1biBvbiBOVklESUEgR1BVLWFjY2VsZXJhdGVkIHN5c3RlbXMgW29yIG5hbWUgZXF1aXZhbGVudCBoYXJkd2FyZSBwcmVmZXJlbmNlXS4gQnkgbGV2ZXJhZ2luZyBOVklESUFcdTIwMTlzIGhhcmR3YXJlIChlLmcuIEdQVSBjb3JlcykgYW5kIHNvZnR3YXJlIGZyYW1ld29ya3MgKGUuZy4sIENVREEgbGlicmFyaWVzKSwgdGhlIG1vZGVsIGFjaGlldmVzIGZhc3RlciB0cmFpbmluZyBhbmQgaW5mZXJlbmNlIHRpbWVzIGNvbXBhcmVkIHRvIENQVS1vbmx5IHNvbHV0aW9ucy4gPGJyPiAgIFxuXG4jIyBTb2Z0d2FyZSBJbnRlZ3JhdGlvbjogPGJyPlxuKipSdW50aW1lIEVuZ2luZShzKToqKiA8YnI+XG4qIE5lTW8gRnJhbWV3b3JrIChiYXNlZCBvbiAyNS4wNyk8YnI+XG5cblxuKipTdXBwb3J0ZWQgSGFyZHdhcmUgTWljcm9hcmNoaXRlY3R1cmUgQ29tcGF0aWJpbGl0eToqKiA8YnI+XG4qIE5WSURJQSBCbGFja3dlbGw6IEIyMDAgPGJyPlxuKiBOVklESUEgSG9wcGVyOiBIMjAwXG5cblxuKipPcGVyYXRpbmcgU3lzdGVtKHMpOioqIExpbnV4IFxuXG4jIyBNb2RlbCBWZXJzaW9uKHMpOiBcbmBncHQtb3NzLTEyMGJgIHYxLjAgKEF1Z3VzdCA1LCAyMDI1KVxuXG5cbiMjIFRyYWluaW5nLCBUZXN0aW5nLCBhbmQgRXZhbHVhdGlvbiBEYXRhc2V0czogPGJyPiAgIFxuIyMjIFRyYWluaW5nIERhdGFzZXQ6XG5cbiogKipUcmFpbmluZyBEYXRhIENvbGxlY3Rpb246KiogVW5kaXNjbG9zZWQgPGJyPlxuKiAqKlRyYWluaW5nIExhYmVsaW5nOioqIFVuZGlzY2xvc2VkIDxicj5cbiogKipUcmFpbmluZyBQcm9wZXJ0aWVzOioqIFRoZSBtb2RlbCBoYXMgYXBwcm94aW1hdGVseSAxMTcgYmlsbGlvbiBwYXJhbWV0ZXJzLiBXZWlnaHRzIGZvciBhbGwgbGF5ZXJzIGFyZSBpbiBCRjE2LCBleGNlcHQgZm9yIE1vRSBwcm9qZWN0aW9uIHdlaWdodHMsIHdoaWNoIGFyZSBpbiBNWEZQNC4gVGhlIHJlZmVyZW5jZSBpbXBsZW1lbnRhdGlvbiBjdXJyZW50bHkgdXBjYXN0cyBhbGwgd2VpZ2h0cyB0byBCRjE2LiBBY3RpdmF0aW9ucyBhcmUgZXhwZWN0ZWQgdG8gYmUgaW4gQkYxNiBvciBGUDguXG5cblxuIyMjIFRlc3RpbmcgRGF0YXNldDpcbiogKipUZXN0aW5nIERhdGEgQ29sbGVjdGlvbjoqKiBVbmRpc2Nsb3NlZCA8YnI+XG4qICoqVGVzdGluZyBMYWJlbGluZzoqKiBVbmRpc2Nsb3NlZCA8YnI+XG4qICoqVGVzdGluZyBQcm9wZXJ0aWVzOioqIFRoZSBtb2RlbCBpcyB0ZXN0ZWQgYWdhaW5zdCBiZW5jaG1hcmtzIHN1Y2ggYXMgTU1MVSBhbmQgR1BRQSwgYW1vbmcgb3RoZXJzIGluY2x1ZGluZyBMaXZlQ29kZUJlbmNoLCBBSU1FIDIwMjQsIGFuZCBNQVRILTUwMC4gXG5cbiMjIyBFdmFsdWF0aW9uIERhdGFzZXQ6XG5cbiogKipFdmFsdWF0aW9uIERhdGEgQ29sbGVjdGlvbjoqKiBVbmRpc2Nsb3NlZCA8YnI+XG4qICoqRXZhbHVhdGlvbiBMYWJlbGluZzoqKiBVbmRpc2Nsb3NlZCA8YnI+XG4qICoqRXZhbHVhdGlvbiBCZW5jaG1hcmsgU2NvcmU6KiogXG5cbnwgQmVuY2htYXJrICB8IGdwdC1vc3MtMTIwYiB8IGdwdC1vc3MtMjBiIHxcbnwtLS0tLS0tLS0tfC0tLS0tLS0tLS0tfCAtLS0tLS0tLS0tLXxcbnwgQUlNRSAyMDI0IChubyB0b29scykgfCA5NS44ICAgfCA5Mi4xIHxcbnwgQUlNRSAyMDI0ICh3aXRoIHRvb2xzKSB8IDk2LjYgfCA5Ni4wIHxcbnwgQUlNRSAyMDI1IChubyB0b29scykgfCA5Mi41ICB8IDkxLjcgfFxufCBBSU1FIDIwMjUgKHdpdGggdG9vbHMpIHwgOTcuOSB8IDk4LjcgfFxufCBHUFFBIERpYW1vbmQgKG5vIHRvb2xzKSB8IDgwLjEgfCA3MS41IHxcbnwgR1BRQSBEaWFtb25kICh3aXRoIHRvb2xzKSB8IDgwLjkgfCA3NC4yIHxcbnwgSExFIChubyB0b29scykgfCAxNC45IHwgMTAuOSB8XG58IEhMRSAod2l0aCB0b29scykgfCAxOS4wIHwgMTcuMyB8XG58IE1NTFUgfCA5MC4wIHwgODUuMyB8XG58IFNXRS1CZW5jaCBWZXJpZmllZCB8IDYyLjQgfCA2MC43IHxcbnwgVGF1LUJlbmNoIFJldGFpbCB8IDY3LjggfCA1NC40IHxcbnwgVGF1LUJlbmNoIEFpcmxpbmUgfCA0OS4yIHwgMzguMCB8XG58IEFpZGVyIFBvbHlnbG90IHwgNDQuNCB8IDM0LjIgfFxufCBNTU1MVSAoQXZlcmFnZSkgfCA4MS4zIHwgNzUuNiB8XG58IEhlYWx0aEJlbmNoIHwgNTcuNiB8IDQyLjUgfFxufCBIZWFsdGhCZW5jaCBIYXJkIHwgMzAuMCB8IDEwLjggfFxufCBIZWFsdGhCZW5jaCBDb25zZW5zdXMgfCA4OS45IHwgODIuNiB8XG58IENvZGVmb3JjZXMgKG5vIHRvb2xzKSBbZWxvXSB8IDI0NjMgfCAyMjMwIHxcbnwgQ29kZWZvcmNlcyAod2l0aCB0b29scykgW2Vsb10gfCAyNjIyIHwgMjUxNiB8XG5cbkFib3ZlIHNjb3JlcyB3ZXJlIG1lYXN1cmVkIGZvciB0aGUgaGlnaCByZWFzb25pbmcgbGV2ZWwuXG5cbiMjIyBTYWZldHkgUmVzdWx0czpcblxuVGhlIGZvbGxvd2luZyBldmFsdWF0aW9ucyBjaGVjayB0aGF0IHRoZSBtb2RlbCBkb2VzIG5vdCBjb21wbHkgd2l0aCByZXF1ZXN0cyBmb3IgY29udGVudCB0aGF0IGlzXG5kaXNhbGxvd2VkIHVuZGVyIE9wZW5BSVx1MjAxOXMgc2FmZXR5IHBvbGljaWVzLCBpbmNsdWRpbmcgaGF0ZWZ1bCBjb250ZW50IG9yIGlsbGljaXQgYWR2aWNlLlxuXG58IENhdGVnb3J5ICB8IGdwdC1vc3MtMTIwYiB8IGdwdC1vc3MtMjBiIHxcbnwtLS0tLS0tLS0tfC0tLS0tLS0tLS0tfCAtLS0tLS0tLS0tLXxcbnwgaGF0ZSAoYWdncmVnYXRlKSB8IDAuOTk2ICAgfCAwLjk5NiB8XG58IHNlbGYtaGFybS9pbnRlbnQgYW5kIHNlbGZoYXJtL2luc3RydWN0aW9ucyB8IDAuOTk1IHwgMC45ODQgfFxufCBwZXJzb25hbCBkYXRhL3NlbWkgcmVzdHJpY3RpdmUgfCAwLjk2NyAgfCAwLjk0NyB8XG58IHNleHVhbC9leHBsb2l0YXRpdmUgfCAxLjAwMCB8IDAuOTgwIHxcbnwgc2V4dWFsL21pbm9ycyB8IDEuMDAwIHwgMC45NzEgfFxufCBpbGxpY2l0L25vbi12aW9sZW50IHwgMS4wMDAgfCAwLjk4MyB8XG58IGlsbGljaXQvdmlvbGVudCB8IDEuMDAwIHwgMS4wMDAgfFxufCBwZXJzb25hbCBkYXRhL3Jlc3RyaWN0ZWQgfCAwLjk5NiB8IDAuOTc4IHxcblxuIyMgSW5mZXJlbmNlOlxuKipBY2NlbGVyYXRpb24gRW5naW5lOioqIHZMTE0gPGJyPlxuKipUZXN0IEhhcmR3YXJlOioqIE5WSURJQSBIb3BwZXI6IEIyMDAgPGJyPlxuXG5cbiMjIEFkZGl0aW9uYWwgRGV0YWlsc1xuVGhlIG1vZGVsIGlzIHJlbGVhc2VkIHdpdGggdGhlIG5hdGl2ZSBxdWFudGl6YXRpb24gc3VwcG9ydC4gU3BlY2lmaWNhbGx5LCBbTVhGUDRdKGh0dHBzOi8vd3d3Lm9wZW5jb21wdXRlLm9yZy9kb2N1bWVudHMvb2NwLW1pY3Jvc2NhbGluZy1mb3JtYXRzLW14LXYxLTAtc3BlYy1maW5hbC1wZGYpIGlzIHVzZWQgZm9yIHRoZSBsaW5lYXIgcHJvamVjdGlvbiB3ZWlnaHRzIGluIHRoZSBNb0UgbGF5ZXIuIEl0IGlzIHN0b3JlZCB0aGUgTW9FIHRlbnNvciBpbiB0d28gcGFydHM6XG5cbi0gYHRlbnNvci5ibG9ja3NgIHN0b3JlcyB0aGUgYWN0dWFsIGZwNCB2YWx1ZXMuIEV2ZXJ5IHR3byB2YWx1ZXMgYXJlIHBhY2tlZCBpbiBvbmUgYHVpbnQ4YCB2YWx1ZS5cbi0gYHRlbnNvci5zY2FsZXNgIHN0b3JlcyB0aGUgYmxvY2sgc2NhbGUuIFRoZSBibG9jayBzY2FsaW5nIGlzIGRvbmUgYW1vbmcgdGhlIGxhc3QgZGltZW5zaW9uIGZvciBhbGwgTVhGUDQgdGVuc29ycy5cblxuQWxsIG90aGVyIHRlbnNvcnMgYXJlIHN0b3JlZCBpbiBCRjE2LiBJdCBpcyByZWNvbW1lbmRlZCB0byB1c2UgQkYxNiBhcyB0aGUgYWN0aXZhdGlvbiBwcmVjaXNpb24gZm9yIHRoZSBtb2RlbC5cblxuIyMgRXRoaWNhbCBDb25zaWRlcmF0aW9uczpcbk5WSURJQSBiZWxpZXZlcyBUcnVzdHdvcnRoeSBBSSBpcyBhIHNoYXJlZCByZXNwb25zaWJpbGl0eSBhbmQgd2UgaGF2ZSBlc3RhYmxpc2hlZCBwb2xpY2llcyBhbmQgcHJhY3RpY2VzIHRvIGVuYWJsZSBkZXZlbG9wbWVudCBmb3IgYSB3aWRlIGFycmF5IG9mIEFJIGFwcGxpY2F0aW9ucy4gIFdoZW4gZG93bmxvYWRlZCBvciB1c2VkIGluIGFjY29yZGFuY2Ugd2l0aCBvdXIgdGVybXMgb2Ygc2VydmljZSwgZGV2ZWxvcGVycyBzaG91bGQgd29yayB3aXRoIHRoZWlyIGludGVybmFsIG1vZGVsIHRlYW0gdG8gZW5zdXJlIHRoaXMgbW9kZWwgbWVldHMgcmVxdWlyZW1lbnRzIGZvciB0aGUgcmVsZXZhbnQgaW5kdXN0cnkgYW5kIHVzZSBjYXNlIGFuZCBhZGRyZXNzZXMgdW5mb3Jlc2VlbiBwcm9kdWN0IG1pc3VzZS4gIFxuXG5QbGVhc2UgcmVwb3J0IHNlY3VyaXR5IHZ1bG5lcmFiaWxpdGllcyBvciBOVklESUEgQUkgQ29uY2VybnMgW2hlcmVdKGh0dHBzOi8vd3d3Lm52aWRpYS5jb20vZW4tdXMvc3VwcG9ydC9zdWJtaXQtc2VjdXJpdHktdnVsbmVyYWJpbGl0eS8pLiIsCiAgICAiZGlzcGxheU5hbWUiOiAiR1BULU9TUy0xMjBCIiwKICAgICJleHBsYWluYWJpbGl0eSI6ICIiLAogICAgImZyYW1ld29yayI6ICJPdGhlciIsCiAgICAiaGFzUGxheWdyb3VuZCI6IGZhbHNlLAogICAgImhhc1NpZ25lZFZlcnNpb24iOiB0cnVlLAogICAgImlzUGxheWdyb3VuZEVuYWJsZWQiOiBmYWxzZSwKICAgICJpc1B1YmxpYyI6IGZhbHNlLAogICAgImlzUmVhZE9ubHkiOiB0cnVlLAogICAgImxhYmVscyI6IFsKICAgICAgICAiTlNQRUNULUVFWlMtN0pCTSIsCiAgICAgICAgIlNpZ25lZCBNb2RlbHMiLAogICAgICAgICJudmFpZTptb2RlbDpudmFpZV9zdXBwb3J0ZWQiLAogICAgICAgICJudmlkaWFfbmltOm1vZGVsOm5pbW1jcm9fbnZpZGlhX25pbSIsCiAgICAgICAgInByb2R1Y3ROYW1lczpuaW0tZGV2IiwKICAgICAgICAicHJvZHVjdE5hbWVzOm52LWFpLWVudGVycHJpc2UiCiAgICBdLAogICAgImxhdGVzdFZlcnNpb25JZFN0ciI6ICJoZi04YjE5M2IwLW5pbSIsCiAgICAibGF0ZXN0VmVyc2lvblNpemVJbkJ5dGVzIjogNjUyNzY4NTk4NzUsCiAgICAibG9nbyI6ICJodHRwczovL2Fzc2V0cy5uZ2MubnZpZGlhLmNvbS9wcm9kdWN0cy9hcGktY2F0YWxvZy9pbWFnZXMvZ3B0LW9zcy0xMjBiLmpwZyIsCiAgICAibW9kZWxGb3JtYXQiOiAiU2F2ZWRNb2RlbCIsCiAgICAibmFtZSI6ICJncHQtb3NzLTEyMGIiLAogICAgIm9yZ05hbWUiOiAibmltIiwKICAgICJwcmVjaXNpb24iOiAiT1RIRVIiLAogICAgInByaXZhY3kiOiAiIiwKICAgICJwcm9kdWN0TmFtZXMiOiBbCiAgICAgICAgIm5pbS1kZXYiLAogICAgICAgICJudi1haS1lbnRlcnByaXNlIgogICAgXSwKICAgICJwdWJsaWNEYXRhc2V0VXNlZCI6IHt9LAogICAgInB1Ymxpc2hlciI6ICJPcGVuQUkiLAogICAgInNhZmV0eUFuZFNlY3VyaXR5IjogIiIsCiAgICAic2hvcnREZXNjcmlwdGlvbiI6ICJPcGVuQUkgcmVsZWFzZXMgdGhlIGdwdC1vc3MgZmFtaWx5IG9mIG9wZW4td2VpZ2h0IG1vZGVscyBkZXNpZ25lZCBmb3IgcG93ZXJmdWwgcmVhc29uaW5nLCBhZ2VudGljIHRhc2tzLCBhbmQgdmVyc2F0aWxlIGRldmVsb3BlciB1c2UgY2FzZXMuIiwKICAgICJ0ZWFtTmFtZSI6ICJvcGVuYWkiLAogICAgInVwZGF0ZWREYXRlIjogIjIwMjUtMDktMDRUMjA6MTU6MTguNzQ4WiIKfQ==
     source:
@@ -1488,6 +1608,126 @@ models:
         value: 8
       - key: GPU DEVICE
         value: 26B9:10DE
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 61GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/openai/gpt-oss-120b:hf-8b193b0-nim-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: GPT-OSS 120B RTX6000_BLACKWELL_SVx1 MXFP4
+      ngcMetadata:
+        7ee480d91bf63c0d1595758d3bd76d4aeaaa5395e8f049ea6893fa55a0cf1268:
+          model: openai/gpt-oss-120b
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '243.0'
+            pp: '1'
+            precision: mxfp4
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: MXFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 61GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/openai/gpt-oss-120b:hf-8b193b0-nim-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: GPT-OSS 120B RTX6000_BLACKWELL_SVx2 MXFP4
+      ngcMetadata:
+        6d13f5550d09f7ea938153a2740238d850afed7c9ed9efdb8887982dc7fd31a0:
+          model: openai/gpt-oss-120b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '127.0'
+            pp: '1'
+            precision: mxfp4
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: MXFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 61GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/openai/gpt-oss-120b:hf-8b193b0-nim-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: GPT-OSS 120B RTX6000_BLACKWELL_SVx4 MXFP4
+      ngcMetadata:
+        41b9c476d251bd06e92d98ffb8f22329059d878ce319e7c776ee51d3bacd153a:
+          model: openai/gpt-oss-120b
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '69.0'
+            pp: '1'
+            precision: mxfp4
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: MXFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 61GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/openai/gpt-oss-120b:hf-8b193b0-nim-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: GPT-OSS 120B RTX6000_BLACKWELL_SVx8 MXFP4
+      ngcMetadata:
+        1c82e31a9fdb6f8cad58b9a9fc561c23fd2074a183b47e51548335514f99a610:
+          model: openai/gpt-oss-120b
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '40.0'
+            pp: '1'
+            precision: mxfp4
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: MXFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
       - key: NIM VERSION
         value: 2.0.3
       - key: DOWNLOAD SIZE

--- a/models/public/1.59.0/llama-3.1-instruct.yaml
+++ b/models/public/1.59.0/llama-3.1-instruct.yaml
@@ -867,6 +867,247 @@ models:
         value: 9GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
+    - profileId: nim/meta/llama-3.1-8b-instruct-pb25h2:8c22764a7e3675c50d4c7c9a4edb474456022b16_pb25h2-rtx6000_blackwell_sv__5
+      framework: VLLM
+      displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx1 BF16
+      ngcMetadata:
+        925771095bbfd8bca1cc2a1ea4a91ecba85b2d68493f0dad3b85bb6c209d8730:
+          model: meta/llama-3.1-8b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'true'
+            feat_lora_max_rank: '32'
+            llm_engine: vllm
+            nim_workspace_hash_v1: e6913c5e344dca0d1286eb01a7f7b0016bb14d50e0bca8fef5a30c08a0d75144
+            pp: '1'
+            precision: bf16
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 30GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.1-8b-instruct-pb25h2:8c22764a7e3675c50d4c7c9a4edb474456022b16_pb25h2-rtx6000_blackwell_sv
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx1 BF16 Throughput
+      ngcMetadata:
+        010bb9e16e9322ddce6db6e6a7d8c844c0ec2ed3d8358a0127dc4cf1114c724a:
+          model: meta/llama-3.1-8b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 555b1cabcde42da61eb1cb14883d71f6e921dd1f171183f7ad27680f45c0412f
+            number_of_gpus: '1'
+            pp: '1'
+            precision: bf16
+            profile: throughput
+            tp: '1'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: THROUGHPUT
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 30GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/meta/llama-3.1-8b-instruct-pb25h2:8c22764a7e3675c50d4c7c9a4edb474456022b16_pb25h2-rtx6000_blackwell_sv__2
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx1 FP8 Latency
+      ngcMetadata:
+        0a929ddd7dadd0bed6a633e6b2ec1e6a90a92ccb60fbe3dd36be97f17328e965:
+          model: meta/llama-3.1-8b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: d61e398017263380bfabf947395e155a35ea873a0a95e468fcf30fdfcb2274fd
+            number_of_gpus: '1'
+            pp: '1'
+            precision: fp8
+            profile: latency
+            tp: '1'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: LATENCY
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 30GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/meta/llama-3.1-8b-instruct-pb25h2:8c22764a7e3675c50d4c7c9a4edb474456022b16_pb25h2-rtx6000_blackwell_sv__3
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx1 FP8 Throughput
+      ngcMetadata:
+        31b9c56ca65e6e6e74b3b95dc2233994b78b309c6733a84a485d4cdf8eccc44f:
+          model: meta/llama-3.1-8b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 1f65528a87318fc0ba52aff1a6bed8ea2f986c187e1c3b04c83c5de589b08510
+            number_of_gpus: '1'
+            pp: '1'
+            precision: fp8
+            profile: throughput
+            tp: '1'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: THROUGHPUT
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 30GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/meta/llama-3.1-8b-instruct-pb25h2:8c22764a7e3675c50d4c7c9a4edb474456022b16_pb25h2-rtx6000_blackwell_sv__4
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx1 NVFP4 Throughput
+      ngcMetadata:
+        c7fdb92819af3784195c1be4fd64e2b005281bbf16ad0735c1485050676d4709:
+          model: meta/llama-3.1-8b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 7d02d59a43df163111196b1b019050502069e6c7444fbc65daaf51558bc28f45
+            number_of_gpus: '1'
+            pp: '1'
+            precision: nvfp4
+            profile: throughput
+            tp: '1'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: THROUGHPUT
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 30GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/meta/llama-3.1-8b-instruct-pb25h2:8c22764a7e3675c50d4c7c9a4edb474456022b16_pb25h2-rtx6000_blackwell_sv-tp2__2
+      framework: VLLM
+      displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx2 BF16
+      ngcMetadata:
+        4bf63ad29ec25417108c5fe1f00ee86ea129334e3cd05c7f7e0d862146d2fc2d:
+          model: meta/llama-3.1-8b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            nim_workspace_hash_v1: e6913c5e344dca0d1286eb01a7f7b0016bb14d50e0bca8fef5a30c08a0d75144
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 30GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.1-8b-instruct-pb25h2:8c22764a7e3675c50d4c7c9a4edb474456022b16_pb25h2-rtx6000_blackwell_sv-tp2
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx2 BF16 Latency
+      ngcMetadata:
+        742e4dd3cab8b08be915776df631f67b3a52aea40c4466e009e0fc457b7c137b:
+          model: meta/llama-3.1-8b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: f0073ef6d193a4fd768a55cd04fbc9fbcd949546c2e94010f2ed11e08d299c91
+            number_of_gpus: '2'
+            pp: '1'
+            precision: bf16
+            profile: latency
+            tp: '2'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: LATENCY
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 30GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
   - variantId: Llama 3.1 70B Instruct
     modelCard: ewogICAgImFjY2Vzc1R5cGUiOiAiTk9UX0xJU1RFRCIsCiAgICAiYXBwbGljYXRpb24iOiAiT3RoZXIiLAogICAgImJpYXMiOiAiIiwKICAgICJjYW5HdWVzdERvd25sb2FkIjogZmFsc2UsCiAgICAiY3JlYXRlZERhdGUiOiAiMjAyNS0wNS0yMFQxODoxNzowOS4xMDdaIiwKICAgICJkZXNjcmlwdGlvbiI6ICIjICoqTGxhbWEtMy4xLTcwQi1JbnN0cnVjdCBPdmVydmlldyoqXG5cbiMjICoqRGVzY3JpcHRpb246KipcblxuKipMbGFtYS0zLjEtNzBCLUluc3RydWN0KiogaXMgYSBtdWx0aWxpbmd1YWwgbGFyZ2UgbGFuZ3VhZ2UgbW9kZWwgZnJvbSB0aGUgTWV0YSBMbGFtYSAzLjEgY29sbGVjdGlvbiBvZiBwcmV0cmFpbmVkIGFuZCBpbnN0cnVjdGlvbi10dW5lZCBnZW5lcmF0aXZlIG1vZGVscy4gVGhpcyBtb2RlbCBpcyBvcHRpbWl6ZWQgZm9yIG11bHRpbGluZ3VhbCBkaWFsb2d1ZSB1c2UgY2FzZXMgYW5kIG91dHBlcmZvcm1zIG1hbnkgYXZhaWxhYmxlIG9wZW4tc291cmNlIGFuZCBjbG9zZWQtc291cmNlIGNoYXQgbW9kZWxzIG9uIGNvbW1vbiBpbmR1c3RyeSBiZW5jaG1hcmtzLiBMbGFtYSAzLjEgaXMgYW4gYXV0by1yZWdyZXNzaXZlIGxhbmd1YWdlIG1vZGVsIHRoYXQgdXNlcyBhbiBvcHRpbWl6ZWQgdHJhbnNmb3JtZXIgYXJjaGl0ZWN0dXJlOyB0aGUgdHVuZWQgdmVyc2lvbnMgdXNlIHN1cGVydmlzZWQgZmluZS10dW5pbmcgKFNGVCkgYW5kIHJlaW5mb3JjZW1lbnQgbGVhcm5pbmcgd2l0aCBodW1hbiBmZWVkYmFjayAoUkxIRikgdG8gYWxpZ24gd2l0aCBodW1hbiBwcmVmZXJlbmNlcyBmb3IgaGVscGZ1bG5lc3MgYW5kIHNhZmV0eS5cblxuVGhpcyBtb2RlbCBpcyByZWFkeSBmb3IgY29tbWVyY2lhbC9ub24tY29tbWVyY2lhbCB1c2UuXG5cblRoaXMgdmVyc2lvbiBpbnRyb2R1Y2VzIHN1cHBvcnQgZm9yIEdCMjAwIE5WTDcyLCBHSDIwMCBOVkwyLCBCMjAwIGFuZCBOVkZQNC4gQ1VEQSB1cGRhdGVkIHRvIHZlcnNpb24gMTIuOS4gRm9yIGRldGFpbGVkIGluZm9ybWF0aW9uLCByZWZlciB0byBSZWxlYXNlIFtOb3RlcyBmb3IgTlZJRElBIE5JTSBmb3IgTExNcyBMTE0gMS4xMl0oaHR0cHM6Ly9kb2NzLm52aWRpYS5jb20vbmltL2xhcmdlLWxhbmd1YWdlLW1vZGVscy9sYXRlc3QvcmVsZWFzZS1ub3Rlcy5odG1sKS4gXG5cbiMjICoqVGhpcmQtUGFydHkgQ29tbXVuaXR5IENvbnNpZGVyYXRpb24qKlxuXG5UaGlzIG1vZGVsIGlzIG5vdCBvd25lZCBvciBkZXZlbG9wZWQgYnkgTlZJRElBLiBUaGlzIG1vZGVsIGhhcyBiZWVuIGRldmVsb3BlZCBhbmQgYnVpbHQgdG8gYSB0aGlyZC1wYXJ0eSdzIHJlcXVpcmVtZW50cyBmb3IgdGhpcyBhcHBsaWNhdGlvbiBhbmQgdXNlIGNhc2U7IHNlZSBsaW5rIHRvIE5vbi1OVklESUFcXFttZXRhLWxsYW1hL0xsYW1hLTMuMS03MEItSW5zdHJ1Y3RcXF0gIFxuKFtodHRwczovL2h1Z2dpbmdmYWNlLmNvL21ldGEtbGxhbWEvTGxhbWEtMy4xLTcwQi1JbnN0cnVjdF0oaHR0cHM6Ly9odWdnaW5nZmFjZS5jby9tZXRhLWxsYW1hL0xsYW1hLTMuMS03MEItSW5zdHJ1Y3QpKS4gXG5cbiMjICoqTGljZW5zZS9UZXJtcyBvZiBVc2U6KipcblxuKipHT1ZFUk5JTkcgVEVSTVM6KiogVGhlIE5JTSBjb250YWluZXIgaXMgZ292ZXJuZWQgYnkgdGhlIFtOVklESUEgU29mdHdhcmUgTGljZW5zZSBBZ3JlZW1lbnRdKGh0dHBzOi8vd3d3Lm52aWRpYS5jb20vZW4tdXMvYWdyZWVtZW50cy9lbnRlcnByaXNlLXNvZnR3YXJlL252aWRpYS1zb2Z0d2FyZS1saWNlbnNlLWFncmVlbWVudC8pIGFuZCB0aGUgW1Byb2R1Y3QtU3BlY2lmaWMgVGVybXMgZm9yIE5WSURJQSBBSSBQcm9kdWN0c10oaHR0cHM6Ly93d3cubnZpZGlhLmNvbS9lbi11cy9hZ3JlZW1lbnRzL2VudGVycHJpc2Utc29mdHdhcmUvcHJvZHVjdC1zcGVjaWZpYy10ZXJtcy1mb3ItYWktcHJvZHVjdHMvKTsgYW5kIHRoZSB1c2Ugb2YgdGhlIG1vZGVsIGlzIGdvdmVybmVkIGJ5IHRoZSBbTlZJRElBIENvbW11bml0eSBNb2RlbCBMaWNlbnNlIEFncmVlbWVudF0oaHR0cHM6Ly93d3cubnZpZGlhLmNvbS9lbi11cy9hZ3JlZW1lbnRzL2VudGVycHJpc2Utc29mdHdhcmUvbnZpZGlhLWNvbW11bml0eS1tb2RlbHMtbGljZW5zZS8uKS5cblxuKipBRERJVElPTkFMIElORk9STUFUSU9OOioqIFtMbGFtYSAzLjEgQ29tbXVuaXR5IExpY2Vuc2UgQWdyZWVtZW50XShodHRwczovL3d3dy5sbGFtYS5jb20vbGxhbWEzXzMvbGljZW5zZS8pLiBCdWlsdCB3aXRoIExsYW1hLlxuXG4jIyBHZXQgSGVscFxuXG4jIyMgRW50ZXJwcmlzZSBTdXBwb3J0XG5cbkdldCBhY2Nlc3MgdG8ga25vd2xlZGdlIGJhc2UgYXJ0aWNsZXMgYW5kIHN1cHBvcnQgY2FzZXMgb3IgW3N1Ym1pdCBhIHRpY2tldF0oaHR0cHM6Ly93d3cubnZpZGlhLmNvbS9lbi11cy9kYXRhLWNlbnRlci9wcm9kdWN0cy9haS1lbnRlcnByaXNlLXN1aXRlL3N1cHBvcnQvKS5cblxuKipZb3UgYXJlIHJlc3BvbnNpYmxlIGZvciBlbnN1cmluZyB0aGF0IHlvdXIgdXNlIG9mIE5WSURJQSBwcm92aWRlZCBtb2RlbHMgY29tcGxpZXMgd2l0aCBhbGwgYXBwbGljYWJsZSBsYXdzLioqXG5cbiMjICoqRGVwbG95bWVudCBHZW9ncmFwaHk6KipcblxuR2xvYmFsIFxuXG4jIyAqKlVzZSBDYXNlOioqXG5cbkRldmVsb3BlcnMsIEFJIHJlc2VhcmNoZXJzLCBhbmQgYnVzaW5lc3NlcyB3b3VsZCBiZSBleHBlY3RlZCB0byB1c2UgdGhpcyBzeXN0ZW0gdG8gYnVpbGQgYW5kIHBvd2VyIGEgd2lkZSByYW5nZSBvZiBhcHBsaWNhdGlvbnMgdGhhdCByZXF1aXJlIGFkdmFuY2VkIHJlYXNvbmluZywgaW5zdHJ1Y3Rpb24tZm9sbG93aW5nLCBhbmQgbXVsdGlsaW5ndWFsIGRpYWxvZ3VlIGNhcGFiaWxpdGllcy4gU3BlY2lmaWMgYXBwbGljYXRpb25zIGluY2x1ZGUgY3JlYXRpbmcgc29waGlzdGljYXRlZCBjaGF0Ym90cyBhbmQgdmlydHVhbCBhc3Npc3RhbnRzLCBkZXZlbG9waW5nIHBvd2VyZnVsIGNvbnRlbnQgY3JlYXRpb24gYW5kIHN1bW1hcml6YXRpb24gdG9vbHMsIGJ1aWxkaW5nIGNvbXBsZXggcXVlc3Rpb24tYW5zd2VyaW5nIHN5c3RlbXMsIGFuZCBwb3dlcmluZyBtdWx0aWxpbmd1YWwgY3VzdG9tZXIgc3VwcG9ydCBwbGF0Zm9ybXMuXG5cbiMjICoqUmVsZWFzZSBEYXRlOioqXG5cbkJ1aWxkLk52aWRpYS5jb20gMDcvMjMvMjAyNCB2aWEgIFxuW2xsYW1hLTMuMS03MGItaW5zdHJ1Y3QgTW9kZWwgYnkgTWV0YSB8IE5WSURJQSBOSU1dKGh0dHBzOi8vYnVpbGQubnZpZGlhLmNvbS9tZXRhL2xsYW1hLTNfMS03MGItaW5zdHJ1Y3QpXG5cbkdpdGh1YiAwNy8yMy8yMDI0IHZpYSAgIFxuW2h0dHBzOi8vZ2l0aHViLmNvbS9tZXRhLWxsYW1hL2xsYW1hLW1vZGVscy9ibG9iL21haW4vbW9kZWxzL2xsYW1hM1xcXzEvTElDRU5TRV0oaHR0cHM6Ly9naXRodWIuY29tL21ldGEtbGxhbWEvbGxhbWEtbW9kZWxzL2Jsb2IvbWFpbi9tb2RlbHMvbGxhbWEzXzEvTElDRU5TRSlcblxuSHVnZ2luZ2ZhY2UgMDcvMjMvMjAyNCB2aWEgICBcbltodHRwczovL2h1Z2dpbmdmYWNlLmNvL21ldGEtbGxhbWEvTGxhbWEtMy4xLTcwQi1JbnN0cnVjdF0oaHR0cHM6Ly9odWdnaW5nZmFjZS5jby9tZXRhLWxsYW1hL0xsYW1hLTMuMS03MEItSW5zdHJ1Y3QpXG5cbioqUmVmZXJlbmNlKHMpOioqIFxuXG5baHR0cHM6Ly9odWdnaW5nZmFjZS5jby9tZXRhLWxsYW1hL0xsYW1hLTMuMS03MEItSW5zdHJ1Y3RdKGh0dHBzOi8vaHVnZ2luZ2ZhY2UuY28vbWV0YS1sbGFtYS9MbGFtYS0zLjEtNzBCLUluc3RydWN0KVxuXG4jIyAqKk1vZGVsIEFyY2hpdGVjdHVyZToqKiBcblxuQXJjaGl0ZWN0dXJlIFR5cGU6IFRyYW5zZm9ybWVyICBcbk5ldHdvcmsgQXJjaGl0ZWN0dXJlOiBMbGFtYS0zLjEtNzBCXG5cblRoaXMgbW9kZWwgd2FzIGRldmVsb3BlZCBiYXNlZCBvbiBNZXRhLUxsYW1hLTMuMS03MEIgIFxuW2h0dHBzOi8vaHVnZ2luZ2ZhY2UuY28vbWV0YS1sbGFtYS9MbGFtYS0zLjEtNzBCLUluc3RydWN0XShodHRwczovL2h1Z2dpbmdmYWNlLmNvL21ldGEtbGxhbWEvTGxhbWEtMy4xLTcwQi1JbnN0cnVjdClcblxuTnVtYmVyIG9mIG1vZGVsIHBhcmFtZXRlcnM6IDcuMDYqMTBeMTBcblxuIyMgKipJbnB1dDoqKlxuXG5JbnB1dCBUeXBlKHMpOiBUZXh0IFxuXG5JbnB1dCBGb3JtYXQocyk6IFN0cmluZyBcblxuSW5wdXQgUGFyYW1ldGVyczogT25lLURpbWVuc2lvbmFsICgxRClcblxuT3RoZXIgUHJvcGVydGllcyBSZWxhdGVkIHRvIElucHV0OiBUaGUgbW9kZWwgYWNjZXB0cyBhIHN0cmluZyBvZiB0ZXh0IHdoaWNoIGlzIGNvbnZlcnRlZCBpbnRvIHRva2VucyB1c2luZyB0aGUgbW9kZWwncyBzcGVjaWZpYyB0b2tlbml6ZXIuIFRoZSB0b3RhbCBsZW5ndGggb2YgdGhlIGlucHV0IHByb21wdCBhbmQgdGhlIGdlbmVyYXRlZCBvdXRwdXQgY2Fubm90IGV4Y2VlZCB0aGUgbW9kZWwncyBjb250ZXh0IHdpbmRvdyBvZiAxMjgsMDAwIHRva2Vucy5cblxuIyMgKipPdXRwdXQ6KipcblxuT3V0cHV0IFR5cGUocyk6IFRleHQgXG5cbk91dHB1dCBGb3JtYXQocyk6IFN0cmluZ1xuXG5PdXRwdXQgUGFyYW1ldGVyczogT25lLURpbWVuc2lvbmFsICgxRClcblxuT3RoZXIgUHJvcGVydGllcyBSZWxhdGVkIHRvIE91dHB1dDogVGhlIG1vZGVsIGdlbmVyYXRlcyBhIHN0cmluZyBvZiB0ZXh0LCBwcm9kdWNlZCB0b2tlbiBieSB0b2tlbi4gVGhlIG1heGltdW0gbGVuZ3RoIG9mIHRoZSBvdXRwdXQgaXMgbGltaXRlZCBieSB0aGUgbW9kZWwncyAxMjgsMDAwLXRva2VuIGNvbnRleHQgd2luZG93LCBsZXNzIHRoZSBsZW5ndGggb2YgdGhlIGlucHV0IHByb21wdC4gUG9zdC1wcm9jZXNzaW5nIGlzIHJlcXVpcmVkIHRvIGRlY29kZSB0aGUgbW9kZWwncyB0b2tlbi1iYXNlZCBvdXRwdXQgaW50byBhIHJlYWRhYmxlIHN0cmluZy5cblxuT3VyIEFJIG1vZGVscyBhcmUgZGVzaWduZWQgYW5kL29yIG9wdGltaXplZCB0byBydW4gb24gTlZJRElBIEdQVS1hY2NlbGVyYXRlZCBzeXN0ZW1zLiBCeSBsZXZlcmFnaW5nIE5WSURJQSdzIGhhcmR3YXJlIChlLmcuIEdQVSBjb3JlcykgYW5kIHNvZnR3YXJlIGZyYW1ld29ya3MgKGUuZy4sIENVREEgbGlicmFyaWVzKSwgdGhlIG1vZGVsIGFjaGlldmVzIGZhc3RlciB0cmFpbmluZyBhbmQgaW5mZXJlbmNlIHRpbWVzIGNvbXBhcmVkIHRvIENQVS1vbmx5IHNvbHV0aW9ucy5cblxuIyMgKipTb2Z0d2FyZSBJbnRlZ3JhdGlvbjoqKlxuXG5SdW50aW1lIEVuZ2luZTogdkxMTSwgVGVuc29yUlRcblxuU3VwcG9ydGVkIEhhcmR3YXJlIE1pY3JvYXJjaGl0ZWN0dXJlIENvbXBhdGliaWxpdHk6XG5cbk5WSURJQSBBbXBlcmUgIFxuTlZJRElBIEJsYWNrd2VsbCAgXG5OVklESUEgSG9wcGVyICBcbk5WSURJQSBMb3ZlbGFjZSBcblxuUHJlZmVycmVkIE9wZXJhdGluZyBTeXN0ZW0ocyk6XG5cbkxpbnV4ICAgXG5XaW5kb3dzXG5cblRoZSBpbnRlZ3JhdGlvbiBvZiBmb3VuZGF0aW9uIGFuZCBmaW5lLXR1bmVkIG1vZGVscyBpbnRvIEFJIHN5c3RlbXMgcmVxdWlyZXMgYWRkaXRpb25hbCB0ZXN0aW5nIHVzaW5nIHVzZS1jYXNlLXNwZWNpZmljIGRhdGEgdG8gZW5zdXJlIHNhZmUgYW5kIGVmZmVjdGl2ZSBkZXBsb3ltZW50LiBGb2xsb3dpbmcgdGhlIFYtbW9kZWwgbWV0aG9kb2xvZ3ksIGl0ZXJhdGl2ZSB0ZXN0aW5nIGFuZCB2YWxpZGF0aW9uIGF0IGJvdGggdW5pdCBhbmQgc3lzdGVtIGxldmVscyBhcmUgZXNzZW50aWFsIHRvIG1pdGlnYXRlIHJpc2tzLCBtZWV0IHRlY2huaWNhbCBhbmQgZnVuY3Rpb25hbCByZXF1aXJlbWVudHMsIGFuZCBlbnN1cmUgY29tcGxpYW5jZSB3aXRoIHNhZmV0eSBhbmQgZXRoaWNhbCBzdGFuZGFyZHMgYmVmb3JlIGRlcGxveW1lbnQuXG5cbiMjICoqTW9kZWwgVmVyc2lvbihzKToqKlxuXG5MbGFtYS0zLjEtNzBCLUluc3RydWN0XG5cbiMjICoqVXNhZ2UqKlxuXG4qKlVzZSB3aXRoIHRyYW5zZm9ybWVycyoqXG5cblN0YXJ0aW5nIHdpdGggdHJhbnNmb3JtZXJzIFxcPj0gNC40NS4wIG9ud2FyZCwgeW91IGNhbiBydW4gY29udmVyc2F0aW9uYWwgaW5mZXJlbmNlIHVzaW5nIHRoZSBUcmFuc2Zvcm1lcnMgcGlwZWxpbmUgYWJzdHJhY3Rpb24gb3IgYnkgbGV2ZXJhZ2luZyB0aGUgQXV0byBjbGFzc2VzIHdpdGggdGhlIGdlbmVyYXRlKCkgZnVuY3Rpb24uXG5cbk1ha2Ugc3VyZSB0byB1cGRhdGUgeW91ciB0cmFuc2Zvcm1lcnMgaW5zdGFsbGF0aW9uIHZpYSBwaXAgaW5zdGFsbCBcXC0tdXBncmFkZSB0cmFuc2Zvcm1lcnMuXG5cblNlZSB0aGUgc25pcHBldCBiZWxvdyBmb3IgdXNhZ2Ugd2l0aCBUcmFuc2Zvcm1lcnM6XG5cbmBgYFxuaW1wb3J0IHRyYW5zZm9ybWVyc1xuaW1wb3J0IHRvcmNoXG5cbm1vZGVsX2lkID0gXCJtZXRhLWxsYW1hL01ldGEtTGxhbWEtMy4xLTcwQi1JbnN0cnVjdFwiXG5cbnBpcGVsaW5lID0gdHJhbnNmb3JtZXJzLnBpcGVsaW5lKFxuICAgIFwidGV4dC1nZW5lcmF0aW9uXCIsXG4gICAgbW9kZWw9bW9kZWxfaWQsXG4gICAgbW9kZWxfa3dhcmdzPXtcInRvcmNoX2R0eXBlXCI6IHRvcmNoLmJmbG9hdDE2fSxcbiAgICBkZXZpY2VfbWFwPVwiYXV0b1wiLFxuKVxuXG5tZXNzYWdlcyA9IFtcbiAgICB7XCJyb2xlXCI6IFwic3lzdGVtXCIsIFwiY29udGVudFwiOiBcIllvdSBhcmUgYSBwaXJhdGUgY2hhdGJvdCB3aG8gYWx3YXlzIHJlc3BvbmRzIGluIHBpcmF0ZSBzcGVhayFcIn0sXG4gICAge1wicm9sZVwiOiBcInVzZXJcIiwgXCJjb250ZW50XCI6IFwiV2hvIGFyZSB5b3U/XCJ9LFxuXVxuXG5vdXRwdXRzID0gcGlwZWxpbmUoXG4gICAgbWVzc2FnZXMsXG4gICAgbWF4X25ld190b2tlbnM9MjU2LFxuKVxucHJpbnQob3V0cHV0c1swXVtcImdlbmVyYXRlZF90ZXh0XCJdWy0xXSlcbmBgYFxuXG4qKlRvb2wgdXNlIHdpdGggdHJhbnNmb3JtZXJzKipcblxuTExhTUEtMy4zIHN1cHBvcnRzIG11bHRpcGxlIHRvb2wgdXNlIGZvcm1hdHMuIFlvdSBjYW4gc2VlIGEgZnVsbCBndWlkZSB0byBwcm9tcHQgZm9ybWF0dGluZyBbaGVyZV0oaHR0cHM6Ly9sbGFtYS5tZXRhLmNvbS9kb2NzL21vZGVsLWNhcmRzLWFuZC1wcm9tcHQtZm9ybWF0cy9sbGFtYTNfMS8pLlxuXG5Ub29sIHVzZSBpcyBhbHNvIHN1cHBvcnRlZCB0aHJvdWdoIFtjaGF0IHRlbXBsYXRlc10oaHR0cHM6Ly9odWdnaW5nZmFjZS5jby9kb2NzL3RyYW5zZm9ybWVycy9tYWluL2NoYXRfdGVtcGxhdGluZyNhZHZhbmNlZC10b29sLXVzZS0tZnVuY3Rpb24tY2FsbGluZykgaW4gVHJhbnNmb3JtZXJzLiBIZXJlIGlzIGEgcXVpY2sgZXhhbXBsZSBzaG93aW5nIGEgc2luZ2xlIHNpbXBsZSB0b29sOlxuXG5gYGBcbiMgRmlyc3QsIGRlZmluZSBhIHRvb2xcbmRlZiBnZXRfY3VycmVudF90ZW1wZXJhdHVyZShsb2NhdGlvbjogc3RyKSAtPiBmbG9hdDpcbiAgICBcIlwiXCJcbiAgICBHZXQgdGhlIGN1cnJlbnQgdGVtcGVyYXR1cmUgYXQgYSBsb2NhdGlvbi5cbiAgICBcbiAgICBBcmdzOlxuICAgICAgICBsb2NhdGlvbjogVGhlIGxvY2F0aW9uIHRvIGdldCB0aGUgdGVtcGVyYXR1cmUgZm9yLCBpbiB0aGUgZm9ybWF0IFwiQ2l0eSwgQ291bnRyeVwiXG4gICAgUmV0dXJuczpcbiAgICAgICAgVGhlIGN1cnJlbnQgdGVtcGVyYXR1cmUgYXQgdGhlIHNwZWNpZmllZCBsb2NhdGlvbiBpbiB0aGUgc3BlY2lmaWVkIHVuaXRzLCBhcyBhIGZsb2F0LlxuICAgIFwiXCJcIlxuICAgIHJldHVybiAyMi4gICMgQSByZWFsIGZ1bmN0aW9uIHNob3VsZCBwcm9iYWJseSBhY3R1YWxseSBnZXQgdGhlIHRlbXBlcmF0dXJlIVxuXG4jIE5leHQsIGNyZWF0ZSBhIGNoYXQgYW5kIGFwcGx5IHRoZSBjaGF0IHRlbXBsYXRlXG5tZXNzYWdlcyA9IFtcbiAge1wicm9sZVwiOiBcInN5c3RlbVwiLCBcImNvbnRlbnRcIjogXCJZb3UgYXJlIGEgYm90IHRoYXQgcmVzcG9uZHMgdG8gd2VhdGhlciBxdWVyaWVzLlwifSxcbiAge1wicm9sZVwiOiBcInVzZXJcIiwgXCJjb250ZW50XCI6IFwiSGV5LCB3aGF0J3MgdGhlIHRlbXBlcmF0dXJlIGluIFBhcmlzIHJpZ2h0IG5vdz9cIn1cbl1cblxuaW5wdXRzID0gdG9rZW5pemVyLmFwcGx5X2NoYXRfdGVtcGxhdGUobWVzc2FnZXMsIHRvb2xzPVtnZXRfY3VycmVudF90ZW1wZXJhdHVyZV0sIGFkZF9nZW5lcmF0aW9uX3Byb21wdD1UcnVlKVxuYGBgXG5cbllvdSBjYW4gdGhlbiBnZW5lcmF0ZSB0ZXh0IGZyb20gdGhpcyBpbnB1dCBhcyBub3JtYWwuIElmIHRoZSBtb2RlbCBnZW5lcmF0ZXMgYSB0b29sIGNhbGwsIHlvdSBzaG91bGQgYWRkIGl0IHRvIHRoZSBjaGF0IGxpa2Ugc286XG5cbmBgYFxudG9vbF9jYWxsID0ge1wibmFtZVwiOiBcImdldF9jdXJyZW50X3RlbXBlcmF0dXJlXCIsIFwiYXJndW1lbnRzXCI6IHtcImxvY2F0aW9uXCI6IFwiUGFyaXMsIEZyYW5jZVwifX1cbm1lc3NhZ2VzLmFwcGVuZCh7XCJyb2xlXCI6IFwiYXNzaXN0YW50XCIsIFwidG9vbF9jYWxsc1wiOiBbe1widHlwZVwiOiBcImZ1bmN0aW9uXCIsIFwiZnVuY3Rpb25cIjogdG9vbF9jYWxsfV19KVxuYGBgXG5cbmFuZCB0aGVuIGNhbGwgdGhlIHRvb2wgYW5kIGFwcGVuZCB0aGUgcmVzdWx0LCB3aXRoIHRoZSB0b29sIHJvbGUsIGxpa2Ugc286XG5cbmBgYFxubWVzc2FnZXMuYXBwZW5kKHtcInJvbGVcIjogXCJ0b29sXCIsIFwibmFtZVwiOiBcImdldF9jdXJyZW50X3RlbXBlcmF0dXJlXCIsIFwiY29udGVudFwiOiBcIjIyLjBcIn0pXG5gYGBcblxuQWZ0ZXIgdGhhdCwgeW91IGNhbiBnZW5lcmF0ZSgpIGFnYWluIHRvIGxldCB0aGUgbW9kZWwgdXNlIHRoZSB0b29sIHJlc3VsdCBpbiB0aGUgY2hhdC4gTm90ZSB0aGF0IHRoaXMgd2FzIGEgdmVyeSBicmllZiBpbnRyb2R1Y3Rpb24gdG8gdG9vbCBjYWxsaW5nIFxcLSBmb3IgbW9yZSBpbmZvcm1hdGlvbiwgc2VlIHRoZSBbTExhTUEgcHJvbXB0IGZvcm1hdCBkb2NzXShodHRwczovL2xsYW1hLm1ldGEuY29tL2RvY3MvbW9kZWwtY2FyZHMtYW5kLXByb21wdC1mb3JtYXRzL2xsYW1hM18xLykgYW5kIHRoZSBUcmFuc2Zvcm1lcnMgW3Rvb2wgdXNlIGRvY3VtZW50YXRpb25dKGh0dHBzOi8vaHVnZ2luZ2ZhY2UuY28vZG9jcy90cmFuc2Zvcm1lcnMvbWFpbi9jaGF0X3RlbXBsYXRpbmcjYWR2YW5jZWQtdG9vbC11c2UtLWZ1bmN0aW9uLWNhbGxpbmcpLlxuXG4qKlVzZSB3aXRoIGJpdHNhbmRieXRlcyoqXG5cblRoZSBtb2RlbCBjaGVja3BvaW50cyBjYW4gYmUgdXNlZCBpbiA4LWJpdCBhbmQgNC1iaXQgZm9yIGZ1cnRoZXIgbWVtb3J5IG9wdGltaXNhdGlvbnMgdXNpbmcgYml0c2FuZGJ5dGVzIGFuZCB0cmFuc2Zvcm1lcnNcblxuU2VlIHRoZSBzbmlwcGV0IGJlbG93IGZvciB1c2FnZTpcblxuYGBgXG5pbXBvcnQgdG9yY2hcbmZyb20gdHJhbnNmb3JtZXJzIGltcG9ydCBBdXRvTW9kZWxGb3JDYXVzYWxMTSwgQXV0b1Rva2VuaXplclxuXG5tb2RlbF9pZCA9IFwibWV0YS1sbGFtYS9NZXRhLUxsYW1hLTMuMS03MEItSW5zdHJ1Y3RcIlxucXVhbnRpemF0aW9uX2NvbmZpZyA9IEJpdHNBbmRCeXRlc0NvbmZpZyhsb2FkX2luXzhiaXQ9VHJ1ZSlcblxucXVhbnRpemVkX21vZGVsID0gQXV0b01vZGVsRm9yQ2F1c2FsTE0uZnJvbV9wcmV0cmFpbmVkKFxuICAgIG1vZGVsX2lkLCBkZXZpY2VfbWFwPVwiYXV0b1wiLCB0b3JjaF9kdHlwZT10b3JjaC5iZmxvYXQxNiwgcXVhbnRpemF0aW9uX2NvbmZpZz1xdWFudGl6YXRpb25fY29uZmlnKVxuXG50b2tlbml6ZXIgPSBBdXRvVG9rZW5pemVyLmZyb21fcHJldHJhaW5lZChtb2RlbF9pZClcbmlucHV0X3RleHQgPSBcIldoYXQgYXJlIHdlIGhhdmluZyBmb3IgZGlubmVyP1wiXG5pbnB1dF9pZHMgPSB0b2tlbml6ZXIoaW5wdXRfdGV4dCwgcmV0dXJuX3RlbnNvcnM9XCJwdFwiKS50byhcImN1ZGFcIilcblxub3V0cHV0ID0gcXVhbnRpemVkX21vZGVsLmdlbmVyYXRlKCoqaW5wdXRfaWRzLCBtYXhfbmV3X3Rva2Vucz0xMClcblxucHJpbnQodG9rZW5pemVyLmRlY29kZShvdXRwdXRbMF0sIHNraXBfc3BlY2lhbF90b2tlbnM9VHJ1ZSkpXG5gYGBcblxuVG8gbG9hZCBpbiA0LWJpdCBzaW1wbHkgcGFzcyBsb2FkXFxfaW5cXF80Yml0PVRydWVcblxuKipVc2Ugd2l0aCBsbGFtYSoqXG5cblBsZWFzZSwgZm9sbG93IHRoZSBpbnN0cnVjdGlvbnMgaW4gdGhlIFtyZXBvc2l0b3J5XShodHRwczovL2dpdGh1Yi5jb20vbWV0YS1sbGFtYS9sbGFtYSkuXG5cblRvIGRvd25sb2FkIE9yaWdpbmFsIGNoZWNrcG9pbnRzLCBzZWUgdGhlIGV4YW1wbGUgY29tbWFuZCBiZWxvdyBsZXZlcmFnaW5nIGh1Z2dpbmdmYWNlLWNsaTpcblxuYGBgXG5odWdnaW5nZmFjZS1jbGkgZG93bmxvYWQgbWV0YS1sbGFtYS9NZXRhLUxsYW1hLTMuMS03MEItSW5zdHJ1Y3QgLS1pbmNsdWRlIFwib3JpZ2luYWwvKlwiIC0tbG9jYWwtZGlyIE1ldGEtTGxhbWEtMy4xLTcwQi1JbnN0cnVjdFxuYGBgXG5cbiMjICoqVHJhaW5pbmcsIFRlc3RpbmcsIGFuZCBFdmFsdWF0aW9uIERhdGFzZXRzOioqXG5cbiMjIyAqKlRyYWluaW5nIERhdGFzZXQqKlxuXG4qKkRhdGEgTW9kYWxpdHk6KiogVGV4dCBcblxuKipMaW5rOioqIFVuZGlzY2xvc2VkXG5cbioqRGF0YSBDb2xsZWN0aW9uIE1ldGhvZDoqKiBIeWJyaWQ6IEh1bWFuLCBTeW50aGV0aWMsIEF1dG9tYXRlZFxuXG4qKkxhYmVsaW5nIE1ldGhvZDoqKiBIeWJyaWQ6IEF1dG9tYXRlZCwgSHVtYW5cblxuKipQcm9wZXJ0aWVzOioqIFxuXG5UaGUgcHJldHJhaW5pbmcgZGF0YXNldCBjb250YWlucyBvdmVyIDE1IHRyaWxsaW9uIHRva2Vucy4gSXQgaXMgYSBtdWx0aWxpbmd1YWwgZGF0YXNldCBjb3ZlcmluZyBvdmVyIDMwIGxhbmd1YWdlcyBhbmQgd2FzIGZpbHRlcmVkIGhlYXZpbHkgZm9yIHF1YWxpdHkgdXNpbmcgdmFyaW91cyB0ZWNobmlxdWVzLCBpbmNsdWRpbmcgaGV1cmlzdGljIGZpbHRlcnMsIE5TRlcgZmlsdGVycywgYW5kIHRleHQgY2xhc3NpZmllcnMuIFRoZSBtb2RlbCdzIGtub3dsZWRnZSB3YXMgdHJhaW5lZCBvbiBkYXRhIHdpdGggYSBjdXRvZmYgb2YgRGVjZW1iZXIgMjAyM1xcLiBcblxuIyMjICoqVGVzdGluZyBEYXRhc2V0KipcblxuKipMaW5rOioqIFVuZGlzY2xvc2VkXG5cbioqRGF0YSBDb2xsZWN0aW9uIE1ldGhvZDoqKiBIeWJyaWQ6IEh1bWFuLCBTeW50aGV0aWMsIEF1dG9tYXRlZFxuXG4qKkxhYmVsaW5nIE1ldGhvZDoqKiBIeWJyaWQ6IEF1dG9tYXRlZCwgSHVtYW5cblxuKipQcm9wZXJ0aWVzOioqIFxuXG4qKkRlc2NyaXB0aW9uOioqXG5cblRoZSBtb2RlbCB3YXMgdGVzdGVkIG9uIGEgZGl2ZXJzZSBzZXQgb2YgZXZhbHVhdGlvbiBkYXRhLlxuXG4qIFB1YmxpYyBCZW5jaG1hcmtzOiBUaGVzZSB0ZXN0IGEgd2lkZSByYW5nZSBvZiBjYXBhYmlsaXRpZXMsIGZyb20gZ2VuZXJhbCBrbm93bGVkZ2UgYW5kIHJlYXNvbmluZyAoTU1MVSwgSGVsbGFTd2FnKSB0byBleHBlcnQtbGV2ZWwgcHJvYmxlbS1zb2x2aW5nIChHUFFBKSBhbmQgcHJvZ3JhbW1pbmcgKEh1bWFuRXZhbCwgd2hpY2ggY29udGFpbnMgMTY0IHByb2dyYW1taW5nIHByb2JsZW1zKS4gIFxuKiBJbnRlcm5hbCBFdmFsdWF0aW9uIFNldDogTWV0YSBjcmVhdGVkIGEgbmV3IGhpZ2gtcXVhbGl0eSB0ZXN0IHNldCBvZiAyLDAwMCBwcm9tcHRzIGNvdmVyaW5nIDEyIGtleSB1c2UgY2FzZXMgKGUuZy4sIGNvZGluZywgcmVhc29uaW5nLCBjcmVhdGl2ZSB3cml0aW5nLCBpbnN0cnVjdGlvbiBmb2xsb3dpbmcpLiBUaGlzIHNldCBpcyB1c2VkIGZvciBodW1hbiBldmFsdWF0aW9uIHRvIGFzc2VzcyBwZXJmb3JtYW5jZSBvbiByZWFsLXdvcmxkLCBudWFuY2VkIHRhc2tzLiBcblxuIyMjICoqRXZhbHVhdGlvbiBEYXRhc2V0KipcblxuKipMaW5rOioqIFVuZGlzY2xvc2VkXG5cbioqRGF0YSBDb2xsZWN0aW9uIE1ldGhvZDoqKiBIeWJyaWQ6IEF1dG9tYXRlZCwgSHVtYW4sIFN5bnRoZXRpY1xuXG4qKkxhYmVsaW5nIE1ldGhvZDoqKiBIeWJyaWQ6IEh1bWFuLCBBdXRvbWF0ZWRcblxuKipQcm9wZXJ0aWVzOioqIFxuXG5UaGUgZXZhbHVhdGlvbiBkYXRhc2V0cyBhcmUgZGl2ZXJzZSBhbmQgdGVzdCBhIHdpZGUgc3BlY3RydW0gb2YgY2FwYWJpbGl0aWVzLiBNTUxVIG1lYXN1cmVzIGJyb2FkIG11bHRpdGFzayBrbm93bGVkZ2UuIEdQUUEgYXNzZXNzZXMgYWR2YW5jZWQgcmVhc29uaW5nIHdpdGggZGlmZmljdWx0LCBleHBlcnQtbGV2ZWwgcXVlc3Rpb25zLiBIdW1hbkV2YWwgYW5kIE1BVEggc3BlY2lmaWNhbGx5IHRlc3QgY29kZSBnZW5lcmF0aW9uIGFuZCBtYXRoZW1hdGljYWwgcmVhc29uaW5nIGFiaWxpdGllcywgcmVzcGVjdGl2ZWx5LiBNZXRhIGFsc28gdXRpbGl6ZXMgYSBsYXJnZSwgcHJpdmF0ZSwgaHVtYW4tYW5ub3RhdGVkIGV2YWx1YXRpb24gc2V0IGRlc2lnbmVkIHRvIGFzc2VzcyBtb2RlbCBwZXJmb3JtYW5jZSBpbiByZWFsLXdvcmxkLCBudWFuY2VkIHNjZW5hcmlvcy4gXG5cbioqQmFzZSBwcmV0cmFpbmVkIG1vZGVscyoqXG5cbnwgQ2F0ZWdvcnkgfCBCZW5jaG1hcmsgfCBcXCMgU2hvdHMgfCBNZXRyaWMgfCBMbGFtYSAzIDhCIHwgTGxhbWEgMy4xIDhCIHwgTGxhbWEgMyA3MEIgfCBMbGFtYSAzLjEgNzBCIHwgTGxhbWEgMy4xIDQwNUIgfFxufCA6LS0tLSB8IDotLS0tIHwgOi0tLS0gfCA6LS0tLSB8IDotLS0tIHwgOi0tLS0gfCA6LS0tLSB8IDotLS0tIHwgOi0tLS0gfFxufCBHZW5lcmFsIHwgTU1MVSB8IDUgfCBtYWNyb1xcX2F2Zy9hY2NcXF9jaGFyIHwgNjYuNyB8IDY2LjcgfCA3OS41IHwgNzkuMyB8IDg1LjIgfFxufCAgfCBNTUxVLVBybyAoQ29UKSB8IDUgfCBtYWNyb1xcX2F2Zy9hY2NcXF9jaGFyIHwgMzYuMiB8IDM3LjEgfCA1NS4wIHwgNTMuOCB8IDYxLjYgfFxufCAgfCBBR0lFdmFsIEVuZ2xpc2ggfCAzLTUgfCBhdmVyYWdlL2FjY1xcX2NoYXIgfCA0Ny4xIHwgNDcuOCB8IDYzLjAgfCA2NC42IHwgNzEuNiB8XG58ICB8IENvbW1vblNlbnNlUUEgfCA3IHwgYWNjXFxfY2hhciB8IDcyLjYgfCA3NS4wIHwgODMuOCB8IDg0LjEgfCA4NS44IHxcbnwgIHwgV2lub2dyYW5kZSB8IDUgfCBhY2NcXF9jaGFyIHwgXFwtIHwgNjAuNSB8IFxcLSB8IDgzLjMgfCA4Ni43IHxcbnwgIHwgQklHLUJlbmNoIEhhcmQgKENvVCkgfCAzIHwgYXZlcmFnZS9lbSB8IDYxLjEgfCA2NC4yIHwgODEuMyB8IDgxLjYgfCA4NS45IHxcbnwgIHwgQVJDLUNoYWxsZW5nZSB8IDI1IHwgYWNjXFxfY2hhciB8IDc5LjQgfCA3OS43IHwgOTMuMSB8IDkyLjkgfCA5Ni4xIHxcbnwgS25vd2xlZGdlIHJlYXNvbmluZyB8IFRyaXZpYVFBLVdpa2kgfCA1IHwgZW0gfCA3OC41IHwgNzcuNiB8IDg5LjcgfCA4OS44IHwgOTEuOCB8XG58IFJlYWRpbmcgY29tcHJlaGVuc2lvbiB8IFNRdUFEIHwgMSB8IGVtIHwgNzYuNCB8IDc3LjAgfCA4NS42IHwgODEuOCB8IDg5LjMgfFxufCAgfCBRdUFDIChGMSkgfCAxIHwgZjEgfCA0NC40IHwgNDQuOSB8IDUxLjEgfCA1MS4xIHwgNTMuNiB8XG58ICB8IEJvb2xRIHwgMCB8IGFjY1xcX2NoYXIgfCA3NS43IHwgNzUuMCB8IDc5LjAgfCA3OS40IHwgODAuMCB8XG58ICB8IERST1AgKEYxKSB8IDMgfCBmMSB8IDU4LjQgfCA1OS41IHwgNzkuNyB8IDc5LjYgfCA4NC44IHxcblxuKipJbnN0cnVjdGlvbiB0dW5lZCBtb2RlbHMqKlxuXG58IENhdGVnb3J5IHwgQmVuY2htYXJrIHwgXFwjIFNob3RzIHwgTWV0cmljIHwgTGxhbWEgMyA4QiBJbnN0cnVjdCB8IExsYW1hIDMuMSA4QiBJbnN0cnVjdCB8IExsYW1hIDMgNzBCIEluc3RydWN0IHwgTGxhbWEgMy4xIDcwQiBJbnN0cnVjdCB8IExsYW1hIDMuMSA0MDVCIEluc3RydWN0IHxcbnwgOi0tLS0gfCA6LS0tLSB8IDotLS0tIHwgOi0tLS0gfCA6LS0tLSB8IDotLS0tIHwgOi0tLS0gfCA6LS0tLSB8IDotLS0tIHxcbnwgR2VuZXJhbCB8IE1NTFUgfCA1IHwgbWFjcm9cXF9hdmcvYWNjIHwgNjguNSB8IDY5LjQgfCA4Mi4wIHwgODMuNiB8IDg3LjMgfFxufCAgfCBNTUxVIChDb1QpIHwgMCB8IG1hY3JvXFxfYXZnL2FjYyB8IDY1LjMgfCA3My4wIHwgODAuOSB8IDg2LjAgfCA4OC42IHxcbnwgIHwgTU1MVS1Qcm8gKENvVCkgfCA1IHwgbWljcm9cXF9hdmcvYWNjXFxfY2hhciB8IDQ1LjUgfCA0OC4zIHwgNjMuNCB8IDY2LjQgfCA3My4zIHxcbnwgIHwgSUZFdmFsIHwgIHwgIHwgNzYuOCB8IDgwLjQgfCA4Mi45IHwgODcuNSB8IDg4LjYgfFxufCBSZWFzb25pbmcgfCBBUkMtQyB8IDAgfCBhY2MgfCA4Mi40IHwgODMuNCB8IDk0LjQgfCA5NC44IHwgOTYuOSB8XG58ICB8IEdQUUEgfCAwIHwgZW0gfCAzNC42IHwgMzAuNCB8IDM5LjUgfCA0Ni43IHwgNTAuNyB8XG58IENvZGUgfCBIdW1hbkV2YWwgfCAwIHwgcGFzc0AxIHwgNjAuNCB8IDcyLjYgfCA4MS43IHwgODAuNSB8IDg5LjAgfFxufCAgfCBNQlBQIFxcKysgYmFzZSB2ZXJzaW9uIHwgMCB8IHBhc3NAMSB8IDcwLjYgfCA3Mi44IHwgODIuNSB8IDg2LjAgfCA4OC42IHxcbnwgIHwgTXVsdGlwbC1FIEh1bWFuRXZhbCB8IDAgfCBwYXNzQDEgfCBcXC0gfCA1MC44IHwgXFwtIHwgNjUuNSB8IDc1LjIgfFxufCAgfCBNdWx0aXBsLUUgTUJQUCB8IDAgfCBwYXNzQDEgfCBcXC0gfCA1Mi40IHwgXFwtIHwgNjIuMCB8IDY1LjcgfFxufCBNYXRoIHwgR1NNLThLIChDb1QpIHwgOCB8IGVtXFxfbWFqMUAxIHwgODAuNiB8IDg0LjUgfCA5My4wIHwgOTUuMSB8IDk2LjggfFxufCAgfCBNQVRIIChDb1QpIHwgMCB8IGZpbmFsXFxfZW0gfCAyOS4xIHwgNTEuOSB8IDUxLjAgfCA2OC4wIHwgNzMuOCB8XG58IFRvb2wgVXNlIHwgQVBJLUJhbmsgfCAwIHwgYWNjIHwgNDguMyB8IDgyLjYgfCA4NS4xIHwgOTAuMCB8IDkyLjAgfFxufCAgfCBCRkNMIHwgMCB8IGFjYyB8IDYwLjMgfCA3Ni4xIHwgODMuMCB8IDg0LjggfCA4OC41IHxcbnwgIHwgR29yaWxsYSBCZW5jaG1hcmsgQVBJIEJlbmNoIHwgMCB8IGFjYyB8IDEuNyB8IDguMiB8IDE0LjcgfCAyOS43IHwgMzUuMyB8XG58ICB8IE5leHVzICgwLXNob3QpIHwgMCB8IG1hY3JvXFxfYXZnL2FjYyB8IDE4LjEgfCAzOC41IHwgNDcuOCB8IDU2LjcgfCA1OC43IHxcbnwgTXVsdGlsaW5ndWFsIHwgTXVsdGlsaW5ndWFsIE1HU00gKENvVCkgfCAwIHwgZW0gfCBcXC0gfCA2OC45IHwgXFwtIHwgODYuOSB8IDkxLjYgfFxuXG4qKk11bHRpbGluZ3VhbCBiZW5jaG1hcmtzKipcblxufCBDYXRlZ29yeSB8IEJlbmNobWFyayB8IExhbmd1YWdlIHwgTGxhbWEgMy4xIDhCIHwgTGxhbWEgMy4xIDcwQiB8IExsYW1hIDMuMSA0MDVCIHxcbnwgOi0tLS0gfCA6LS0tLSB8IDotLS0tIHwgOi0tLS0gfCA6LS0tLSB8IDotLS0tIHxcbnwgR2VuZXJhbCB8IE1NTFUgKDUtc2hvdCwgbWFjcm9cXF9hdmcvYWNjKSB8IFBvcnR1Z3Vlc2UgfCA2Mi4xMiB8IDgwLjEzIHwgODQuOTUgfFxufCAgfCAgfCBTcGFuaXNoIHwgNjIuNDUgfCA4MC4wNSB8IDg1LjA4IHxcbnwgIHwgIHwgSXRhbGlhbiB8IDYxLjYzIHwgODAuNCB8IDg1LjA0IHxcbnwgIHwgIHwgR2VybWFuIHwgNjAuNTkgfCA3OS4yNyB8IDg0LjM2IHxcbnwgIHwgIHwgRnJlbmNoIHwgNjIuMzQgfCA3OS44MiB8IDg0LjY2IHxcbnwgIHwgIHwgSGluZGkgfCA1MC44OCB8IDc0LjUyIHwgODAuMzEgfFxufCAgfCAgfCBUaGFpIHwgNTAuMzIgfCA3Mi45NSB8IDc4LjIxIHxcblxuIyMgKipUZWNobmljYWwgTGltaXRhdGlvbnMqKiBcblxuVGVzdGluZyBjb25kdWN0ZWQgdG8gZGF0ZSBoYXMgbm90IGNvdmVyZWQsIG5vciBjb3VsZCBpdCBjb3ZlciwgYWxsIHNjZW5hcmlvcy4gRm9yIHRoZXNlIHJlYXNvbnMsIGFzIHdpdGggYWxsIExMTXMsIHRoZSBtb2RlbCdzIHBvdGVudGlhbCBvdXRwdXRzIGNhbm5vdCBiZSBwcmVkaWN0ZWQgaW4gYWR2YW5jZSwgYW5kIHRoZSBtb2RlbCBtYXkgaW4gc29tZSBpbnN0YW5jZXMgcHJvZHVjZSBpbmFjY3VyYXRlLCBiaWFzZWQgb3Igb3RoZXIgb2JqZWN0aW9uYWJsZSByZXNwb25zZXMgdG8gdXNlciBwcm9tcHRzLiBUaGVyZWZvcmUsIGJlZm9yZSBkZXBsb3lpbmcgdGhpcyBtb2RlbCBpbiBhbnkgYXBwbGljYXRpb25zLCBkZXZlbG9wZXJzIHNob3VsZCBwZXJmb3JtIHNhZmV0eSB0ZXN0aW5nIGFuZCB0dW5pbmcgdGFpbG9yZWQgdG8gdGhlaXIgc3BlY2lmaWMgYXBwbGljYXRpb25zLiBQbGVhc2UgcmVmZXIgdG8gYXZhaWxhYmxlIHJlc291cmNlcyBpbmNsdWRpbmcgdGhlIFtSZXNwb25zaWJsZSBVc2UgR3VpZGVdKGh0dHBzOi8vbGxhbWEubWV0YS5jb20vcmVzcG9uc2libGUtdXNlLWd1aWRlKSwgW1RydXN0IGFuZCBTYWZldHldKGh0dHBzOi8vbGxhbWEubWV0YS5jb20vdHJ1c3QtYW5kLXNhZmV0eS8pIHNvbHV0aW9ucywgYW5kIG90aGVyIFtyZXNvdXJjZXNdKGh0dHBzOi8vbGxhbWEubWV0YS5jb20vZG9jcy9nZXQtc3RhcnRlZC8pIHRvIGxlYXJuIG1vcmUgYWJvdXQgcmVzcG9uc2libGUgZGV2ZWxvcG1lbnQuIFxuXG4jIyAqKkluZmVyZW5jZToqKlxuXG4qKkFjY2VsZXJhdGlvbiBFbmdpbmU6KiogdkxMTSwgVGVuc29yUlQgXG5cbioqVGVzdCBIYXJkd2FyZToqKiBcblxuICBCMjAwIFNYTSAgIFxuICBIMjAwIFNYTSAgXG4gIEgxMDAgU1hNICBcbiAgQTEwMCBTWE0gODBHQiAgXG4gIEExMDAgU1hNIDQwR0IgIFxuICBMNDBTIFBDSWUgIFxuICBBMTBHICBcbiAgSDEwMCBOVkwgIFxuICBIMjAwIE5WTCAgXG4gIEdIMjAwIDk2R0IgIFxuICBHQjIwMCBOVkw3MiAgIFxuICBHSDIwMCBOVkwyICAgICBcbiAgUlRYIDUwOTAgIFxuICBSVFggNDA5MCAgXG4gIFJUWCA2MDAwIEFkYVxuXG4jIyAqKkV0aGljYWwgQ29uc2lkZXJhdGlvbnM6KipcblxuTlZJRElBIGJlbGlldmVzIFRydXN0d29ydGh5IEFJIGlzIGEgc2hhcmVkIHJlc3BvbnNpYmlsaXR5IGFuZCB3ZSBoYXZlIGVzdGFibGlzaGVkIHBvbGljaWVzIGFuZCBwcmFjdGljZXMgdG8gZW5hYmxlIGRldmVsb3BtZW50IGZvciBhIHdpZGUgYXJyYXkgb2YgQUkgYXBwbGljYXRpb25zLiBXaGVuIGRvd25sb2FkZWQgb3IgdXNlZCBpbiBhY2NvcmRhbmNlIHdpdGggb3VyIHRlcm1zIG9mIHNlcnZpY2UsIGRldmVsb3BlcnMgc2hvdWxkIHdvcmsgd2l0aCB0aGVpciBpbnRlcm5hbCBtb2RlbCB0ZWFtIHRvIGVuc3VyZSB0aGlzIG1vZGVsIG1lZXRzIHJlcXVpcmVtZW50cyBmb3IgdGhlIHJlbGV2YW50IGluZHVzdHJ5IGFuZCB1c2UgY2FzZSBhbmQgYWRkcmVzc2VzIHVuZm9yZXNlZW4gcHJvZHVjdCBtaXN1c2UuIFBsZWFzZSByZXBvcnQgc2VjdXJpdHkgdnVsbmVyYWJpbGl0aWVzIG9yIE5WSURJQSBBSSBDb25jZXJucyBbaGVyZV0oaHR0cHM6Ly93d3cubnZpZGlhLmNvbS9lbi11cy9zdXBwb3J0L3N1Ym1pdC1zZWN1cml0eS12dWxuZXJhYmlsaXR5LykuXG5cbllvdSBhcmUgcmVzcG9uc2libGUgZm9yIGVuc3VyaW5nIHRoYXQgeW91ciB1c2Ugb2YgTlZJRElBIHByb3ZpZGVkIG1vZGVscyBjb21wbGllcyB3aXRoIGFsbCBhcHBsaWNhYmxlIGxhd3MuIiwKICAgICJkaXNwbGF5TmFtZSI6ICJMbGFtYS0zLjEtNzBiLWluc3RydWN0IiwKICAgICJleHBsYWluYWJpbGl0eSI6ICIiLAogICAgImZyYW1ld29yayI6ICJPdGhlciIsCiAgICAiaGFzUGxheWdyb3VuZCI6IGZhbHNlLAogICAgImhhc1NpZ25lZFZlcnNpb24iOiB0cnVlLAogICAgImlzUGxheWdyb3VuZEVuYWJsZWQiOiBmYWxzZSwKICAgICJpc1B1YmxpYyI6IGZhbHNlLAogICAgImlzUmVhZE9ubHkiOiB0cnVlLAogICAgImxhYmVscyI6IFsKICAgICAgICAiTGxhbWEzLjEiLAogICAgICAgICJMbGFtYTMuMS03MGItaW5zdHJ1Y3QiLAogICAgICAgICJOSU0iLAogICAgICAgICJOU1BFQ1QtN1MzRi1RRkc4IiwKICAgICAgICAibnZhaWU6bW9kZWw6bnZhaWVfc3VwcG9ydGVkIiwKICAgICAgICAibnZpZGlhX25pbTptb2RlbDpuaW1tY3JvX252aWRpYV9uaW0iLAogICAgICAgICJwcm9kdWN0TmFtZXM6bmltLWRldiIsCiAgICAgICAgInByb2R1Y3ROYW1lczpudi1haS1lbnRlcnByaXNlIgogICAgXSwKICAgICJsYXRlc3RWZXJzaW9uSWRTdHIiOiAicnR4NjAwMC1ibGFja3dlbGwtc3Z4OC1sYXRlbmN5LWJmMTYtYnhpYWdoNGpnZyIsCiAgICAibGF0ZXN0VmVyc2lvblNpemVJbkJ5dGVzIjogMTU3MzU3MjY3OTI3LAogICAgImxvZ28iOiAiaHR0cHM6Ly9hc3NldHMubmdjLm52aWRpYS5jb20vcHJvZHVjdHMvYXBpLWNhdGFsb2cvaW1hZ2VzL2xsYW1hLTNfMS03MGItaW5zdHJ1Y3QuanBnIiwKICAgICJtb2RlbEZvcm1hdCI6ICJTYXZlZE1vZGVsIiwKICAgICJuYW1lIjogImxsYW1hLTMuMS03MGItaW5zdHJ1Y3QiLAogICAgIm9yZ05hbWUiOiAibmltIiwKICAgICJwcmVjaXNpb24iOiAiT1RIRVIiLAogICAgInByaXZhY3kiOiAiIiwKICAgICJwcm9kdWN0TmFtZXMiOiBbCiAgICAgICAgIm5pbS1kZXYiLAogICAgICAgICJudi1haS1lbnRlcnByaXNlIgogICAgXSwKICAgICJwdWJsaWNEYXRhc2V0VXNlZCI6IHt9LAogICAgInB1Ymxpc2hlciI6ICJNZXRhIiwKICAgICJzYWZldHlBbmRTZWN1cml0eSI6ICIiLAogICAgInNob3J0RGVzY3JpcHRpb24iOiAiVGhlIE1ldGEgTGxhbWEgMy4xIGNvbGxlY3Rpb24gb2YgbXVsdGlsaW5ndWFsIGxhcmdlIGxhbmd1YWdlIG1vZGVscyAoTExNcykgaXMgYSBjb2xsZWN0aW9uIG9mIHByZXRyYWluZWQgYW5kIGluc3RydWN0aW9uIHR1bmVkIGdlbmVyYXRpdmUgbW9kZWxzIGluIDhCLCA3MEIgYW5kIDQwNUIgc2l6ZXMgKHRleHQgaW4vdGV4dCBvdXQpLiIsCiAgICAidGVhbU5hbWUiOiAibWV0YSIsCiAgICAidXBkYXRlZERhdGUiOiAiMjAyNS0xMC0xNVQxNzo0OToxNS42MDVaIgp9
     source:
@@ -1616,6 +1857,315 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: VLLM
+    - profileId: nim/meta/llama-3.1-70b-instruct-pb25h2:1d54af340dc8906a2d21146191a9c184c35e47bd-rtx6000_blackwell_sv-tp2__3
+      framework: VLLM
+      displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx2 BF16
+      ngcMetadata:
+        39194b5f5858f2dde376844651af70e4471874a29935142320b972a2e3ca0ac5:
+          model: meta/llama-3.1-70b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'true'
+            feat_lora_max_rank: '32'
+            llm_engine: vllm
+            nim_workspace_hash_v1: 299821baf3058c03febd8fbfe6422d1342d72bee844f4d66ca27c24a3b190c0d
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 263GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.1-70b-instruct-pb25h2:1d54af340dc8906a2d21146191a9c184c35e47bd-rtx6000_blackwell_sv-tp2
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx2 FP8 Throughput
+      ngcMetadata:
+        bc57e25851a04ff1f855d632d2f656c8eb1a137e55eba2063adcb8ce1116069d:
+          model: meta/llama-3.1-70b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 43974cb445b2cc0a952d77e6a01d557c0fe4f2a3cc1c35796a1043c57518d3cf
+            number_of_gpus: '2'
+            pp: '1'
+            precision: fp8
+            profile: throughput
+            tp: '2'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: THROUGHPUT
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 263GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/meta/llama-3.1-70b-instruct-pb25h2:1d54af340dc8906a2d21146191a9c184c35e47bd-rtx6000_blackwell_sv-tp2__2
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx2 NVFP4 Throughput
+      ngcMetadata:
+        cab042186e90569e93c02348e34628537983e52ab710d3a4fdf42fc9fa4c569b:
+          model: meta/llama-3.1-70b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 6e54117bf7b0c8b928a004a7b02ae040230bdf0fb2670a5499a6b86de772bf59
+            number_of_gpus: '2'
+            pp: '1'
+            precision: nvfp4
+            profile: throughput
+            tp: '2'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: THROUGHPUT
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 263GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/meta/llama-3.1-70b-instruct-pb25h2:1d54af340dc8906a2d21146191a9c184c35e47bd-rtx6000_blackwell_sv-tp4__4
+      framework: VLLM
+      displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx4 BF16
+      ngcMetadata:
+        006abfcad3d12cfc6571d2e55f09a58957a0e3a5cd39c2df8c10e78f4ce10978:
+          model: meta/llama-3.1-70b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'true'
+            feat_lora_max_rank: '32'
+            llm_engine: vllm
+            nim_workspace_hash_v1: 299821baf3058c03febd8fbfe6422d1342d72bee844f4d66ca27c24a3b190c0d
+            pp: '1'
+            precision: bf16
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 263GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.1-70b-instruct-pb25h2:1d54af340dc8906a2d21146191a9c184c35e47bd-rtx6000_blackwell_sv-tp4__3
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx4 BF16 Throughput
+      ngcMetadata:
+        d917ec97b8b2584fe655c03e9152f33e1e1a485c90b8ced5098787bbcf196c7b:
+          model: meta/llama-3.1-70b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 8dc56a001e709d604284f145342698a414d54dc087b26f2fd39628b586819e8a
+            number_of_gpus: '4'
+            pp: '1'
+            precision: bf16
+            profile: throughput
+            tp: '4'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: THROUGHPUT
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 263GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/meta/llama-3.1-70b-instruct-pb25h2:1d54af340dc8906a2d21146191a9c184c35e47bd-rtx6000_blackwell_sv-tp4
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx4 FP8 Latency
+      ngcMetadata:
+        64bc125ba10664e556b2e4203702c2be799df905a26f16724dc5a5933dbad919:
+          model: meta/llama-3.1-70b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: eab1d9b2ac2520726f1218f41491e57157abcd21ba738a45b37deaa206384073
+            number_of_gpus: '4'
+            pp: '1'
+            precision: fp8
+            profile: latency
+            tp: '4'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: LATENCY
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 263GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/meta/llama-3.1-70b-instruct-pb25h2:1d54af340dc8906a2d21146191a9c184c35e47bd-rtx6000_blackwell_sv-tp4__2
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx4 NVFP4 Latency
+      ngcMetadata:
+        6a59fd6976eb5dc3d7c05f45c35f5aa5de00174b41957767c73c0034d91122e1:
+          model: meta/llama-3.1-70b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: bcb143d582f4a6c76551d735a1b403a716abe7d0bc20cf00d98d8c86ceb2dfe0
+            number_of_gpus: '4'
+            pp: '1'
+            precision: nvfp4
+            profile: latency
+            tp: '4'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: LATENCY
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 263GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/meta/llama-3.1-70b-instruct-pb25h2:1d54af340dc8906a2d21146191a9c184c35e47bd-rtx6000_blackwell_sv-tp8__2
+      framework: VLLM
+      displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx8 BF16
+      ngcMetadata:
+        3dcc4db7b5b522f47bf5c344038e6c8cad918617f954a0b751c9b7fcc5bb4d3f:
+          model: meta/llama-3.1-70b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'true'
+            feat_lora_max_rank: '32'
+            llm_engine: vllm
+            nim_workspace_hash_v1: 299821baf3058c03febd8fbfe6422d1342d72bee844f4d66ca27c24a3b190c0d
+            pp: '1'
+            precision: bf16
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 263GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.1-70b-instruct-pb25h2:1d54af340dc8906a2d21146191a9c184c35e47bd-rtx6000_blackwell_sv-tp8
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx8 BF16 Latency
+      ngcMetadata:
+        9eb233c7c0ee4da16616a30996ab9a65e9b5405708df3a19a06da04ac8a78495:
+          model: meta/llama-3.1-70b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: b84e4f23dec2af9146539c7f2865430fe42d7359aa1b3877c6beb286f0ef8558
+            number_of_gpus: '8'
+            pp: '1'
+            precision: bf16
+            profile: latency
+            tp: '8'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: LATENCY
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 263GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
   labels:
   - Llama
   - Meta

--- a/models/public/1.59.0/llama-3.3-instruct.yaml
+++ b/models/public/1.59.0/llama-3.3-instruct.yaml
@@ -2017,6 +2017,366 @@ models:
         value: 40GB
       - key: LLM ENGINE
         value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:bf16-6f6073b423013f6a7d4d9f39144961bfbfbc386b-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx1 BF16
+      ngcMetadata:
+        120f37d15ce21955b951e9acef346dcdcc0ebb17b9e09c1eef15e803a8b87665:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '174.0'
+            pp: '1'
+            precision: bf16
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 132GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:fp8-rxbjb-qrcq-tool-calling-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx1 FP8
+      ngcMetadata:
+        9dad49c0ef76f964e9295d8071045f0c6a2b52ffdc9cb11b8887adced9370554:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '111.0'
+            pp: '1'
+            precision: fp8
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 68GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:nvfp4-klvd4-nzbq-tool-calling-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx1 NVFP4
+      ngcMetadata:
+        13b2cabe93f6e3d81e056b10d747d4baffc8dc6708977963dbc02c378fe6e7fd:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '82.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 40GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:bf16-6f6073b423013f6a7d4d9f39144961bfbfbc386b-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx2 BF16
+      ngcMetadata:
+        314bf2e552c132bc56ed8503d5bd9f3c159abe5c9ca8a694e5e2081eb7c04649:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '89.0'
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 132GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:fp8-rxbjb-qrcq-tool-calling-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx2 FP8
+      ngcMetadata:
+        74dc099acf027ca44ed08bf7f182582f4f20bef8c9be768908a3a11f55a4803d:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '57.0'
+            pp: '1'
+            precision: fp8
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 68GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:nvfp4-klvd4-nzbq-tool-calling-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx2 NVFP4
+      ngcMetadata:
+        313ac0ae8b3d63007c5c3af22b90e3371d99332aff7a8d19162c0a5dfaaeade5:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '43.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 40GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:bf16-6f6073b423013f6a7d4d9f39144961bfbfbc386b-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx4 BF16
+      ngcMetadata:
+        128b00593671377d1f538c52b7c83d57f6d0bee57b32af3143368a7fe246afea:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '47.0'
+            pp: '1'
+            precision: bf16
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 132GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:fp8-rxbjb-qrcq-tool-calling-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx4 FP8
+      ngcMetadata:
+        16bb57d5dfa4bd677567955d1d4d6977b8bd1f9260139a5cce29ea7a7299b85f:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '31.0'
+            pp: '1'
+            precision: fp8
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 68GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:nvfp4-klvd4-nzbq-tool-calling-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx4 NVFP4
+      ngcMetadata:
+        b99f21d2c604622d124cbd2f922f523bd695690693f43b9dbd0937d43e43922c:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '24.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 40GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:bf16-6f6073b423013f6a7d4d9f39144961bfbfbc386b-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx8 BF16
+      ngcMetadata:
+        2914d34f4fa4833f89591ad3d5f92257d2167acb8ddb298a7ea0ad69629dbb16:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '25.0'
+            pp: '1'
+            precision: bf16
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 132GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:fp8-rxbjb-qrcq-tool-calling-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx8 FP8
+      ngcMetadata:
+        639213f8d80b20fddf456aa7c2e456b3d175b4043d1d5f1694a680757a25dad3:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '18.0'
+            pp: '1'
+            precision: fp8
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 68GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:nvfp4-klvd4-nzbq-tool-calling-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx8 NVFP4
+      ngcMetadata:
+        218de288d43ccaf69332f22c8826ead532723b7de3fbdd294b61051a3f1c83c6:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '15.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 40GB
+      - key: LLM ENGINE
+        value: VLLM
   labels:
   - Llama
   - Meta

--- a/models/public/1.59.0/llama-3.3-nemotron-super-49b.yaml
+++ b/models/public/1.59.0/llama-3.3-nemotron-super-49b.yaml
@@ -2081,6 +2081,366 @@ models:
         value: 29GB
       - key: LLM ENGINE
         value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-checkpoint-bf16-jetart-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx1 BF16
+      ngcMetadata:
+        8c3925b338d0bda8a4c95533c8c39e8ba9d38c2c7d4c687dd9fbc091186fccc1:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '120.0'
+            pp: '1'
+            precision: bf16
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 93GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:fp8-rmctserfba-tool-calling-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx1 FP8
+      ngcMetadata:
+        442b97776dbd568ef529479d866b000c7bd16b5f5d2422c213a0b3b1624c9281:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '76.0'
+            pp: '1'
+            precision: fp8
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 49GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:nvfp4-biyprhc44a-tool-calling-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx1 NVFP4
+      ngcMetadata:
+        50e2f862b5fe96cba5e45e2092d38845fa54104dcc03f4c0b2bdb23b4d05b6aa:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '56.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 29GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-checkpoint-bf16-jetart-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx2 BF16
+      ngcMetadata:
+        1146f49f84dff5dea09f5aa633cc70b92d7d972223d67878c841cd0fbccad4fb:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '62.0'
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 93GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:fp8-rmctserfba-tool-calling-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx2 FP8
+      ngcMetadata:
+        539eab4f3514e65516789d3bd11e4102aae5065a86e7cfb7688950bb456ce239:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '40.0'
+            pp: '1'
+            precision: fp8
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 49GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:nvfp4-biyprhc44a-tool-calling-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx2 NVFP4
+      ngcMetadata:
+        1952dc27de2122a4aadff950e4f7c6f7f383cdc63500c6bb483cc4d7fc930196:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '30.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 29GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-checkpoint-bf16-jetart-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx4 BF16
+      ngcMetadata:
+        6ffcc333dec0c7f62e8589513d5682d1268f47c552f6fc978080dd2c30389ba8:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '33.0'
+            pp: '1'
+            precision: bf16
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 93GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:fp8-rmctserfba-tool-calling-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx4 FP8
+      ngcMetadata:
+        18c1c9566d039d78881db55dd30907348afd73ff75f4e262aa1af824e320aa55:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '22.0'
+            pp: '1'
+            precision: fp8
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 49GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:nvfp4-biyprhc44a-tool-calling-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx4 NVFP4
+      ngcMetadata:
+        5122caf75c64b197b8d2170464500fd2aab69aa4d66c278629f7894271ca3ab9:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '17.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 29GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-checkpoint-bf16-jetart-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx8 BF16
+      ngcMetadata:
+        c7e34d09ffb6939d600faab0b43370ae4527cb008f2635464a53d9b46a368b27:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '19.0'
+            pp: '1'
+            precision: bf16
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 93GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:fp8-rmctserfba-tool-calling-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx8 FP8
+      ngcMetadata:
+        651f21dff2c1193dd7e606701ad1e18d5e35fe0cdc597f0b08a4af2609824af1:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '13.0'
+            pp: '1'
+            precision: fp8
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 49GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:nvfp4-biyprhc44a-tool-calling-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx8 NVFP4
+      ngcMetadata:
+        32dcea516a998a70f3069cdfbcc781de6c492c344cb38a29780f249fdb190e4d:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '11.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 29GB
+      - key: LLM ENGINE
+        value: VLLM
   labels:
   - Llama
   - Meta

--- a/models/public/1.59.0/minimax-m25.yaml
+++ b/models/public/1.59.0/minimax-m25.yaml
@@ -647,6 +647,108 @@ models:
         value: 215GB
       - key: LLM ENGINE
         value: SGLANG
+    - profileId: nim/minimax-ai/minimax-m25:hf-3040beaf-nim-rtx6000_blackwell_sv-tp2
+      framework: SGLang
+      displayName: Minimax M25 RTX6000_BLACKWELL_SVx2 FP8 Fallback
+      ngcMetadata:
+        2605f42cb4d0b90a89f44cfc23971278d95665b988d6d94b7e9b06326c21598f:
+          model: minimax-ai/minimax-m25
+          release: 1.7.1
+          tags:
+            ep: '1'
+            feat_lora: 'false'
+            llm_engine: sglang
+            pp: '1'
+            precision: fp8
+            profile: fallback
+            tp: '2'
+            vram: 300GiB
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: sglang
+      spec:
+      - key: PROFILE
+        value: FALLBACK
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 1.7.1
+      - key: DOWNLOAD SIZE
+        value: 215GB
+      - key: LLM ENGINE
+        value: SGLANG
+    - profileId: nim/minimax-ai/minimax-m25:hf-3040beaf-nim-rtx6000_blackwell_sv-tp4
+      framework: SGLang
+      displayName: Minimax M25 RTX6000_BLACKWELL_SVx4 FP8 Fallback
+      ngcMetadata:
+        15ebdb7833a74321359ccb332924083139a63677c5f16193f36f82874133b46a:
+          model: minimax-ai/minimax-m25
+          release: 1.7.1
+          tags:
+            ep: '1'
+            feat_lora: 'false'
+            llm_engine: sglang
+            pp: '1'
+            precision: fp8
+            profile: fallback
+            tp: '4'
+            vram: 300GiB
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: sglang
+      spec:
+      - key: PROFILE
+        value: FALLBACK
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 1.7.1
+      - key: DOWNLOAD SIZE
+        value: 215GB
+      - key: LLM ENGINE
+        value: SGLANG
+    - profileId: nim/minimax-ai/minimax-m25:hf-3040beaf-nim-rtx6000_blackwell_sv-tp8
+      framework: SGLang
+      displayName: Minimax M25 RTX6000_BLACKWELL_SVx8 FP8 Fallback
+      ngcMetadata:
+        ecc4f617f49bfa40d40c24eb3f0550233071bb62c387001be3155ee63c1a1ac0:
+          model: minimax-ai/minimax-m25
+          release: 1.7.1
+          tags:
+            ep: '8'
+            feat_lora: 'false'
+            llm_engine: sglang
+            pp: '1'
+            precision: fp8
+            profile: fallback
+            tp: '8'
+            vram: 300GiB
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: sglang
+      spec:
+      - key: PROFILE
+        value: FALLBACK
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 1.7.1
+      - key: DOWNLOAD SIZE
+        value: 215GB
+      - key: LLM ENGINE
+        value: SGLANG
   labels:
   - Multimodal
   - Minimax

--- a/models/public/1.59.0/mixtral-instruct.yaml
+++ b/models/public/1.59.0/mixtral-instruct.yaml
@@ -1303,6 +1303,274 @@ models:
         value: 87GB
       - key: LLM ENGINE
         value: VLLM
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v0-1:hf-a60832c-tool-use-v2-rtx6000_blackwell_sv__5
+      framework: VLLM
+      displayName: Mixtral 8x7b Instruct V0.1 RTX6000_BLACKWELL_SVx1 BF16
+      ngcMetadata:
+        61c1479f4e611effdbb853dbf3723f9f483f9261a16d05e67e8f122906bc9f05:
+          model: mistralai/mixtral-8x7b-instruct-v0.1
+          release: 1.12.0
+          tags:
+            feat_lora: 'true'
+            feat_lora_max_rank: '32'
+            llm_engine: vllm
+            nim_workspace_hash_v1: 1143086cd34eaa9e23556534ece80597734ec4653acf4ed38fc87f993b235371
+            pp: '1'
+            precision: bf16
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 1.12.0
+      - key: DOWNLOAD SIZE
+        value: 87GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v0-1:hf-a60832c-tool-use-v2-rtx6000_blackwell_sv
+      framework: TensorRT-LLM
+      displayName: Mixtral 8x7b Instruct V0.1 RTX6000_BLACKWELL_SVx1 BF16 Latency
+      ngcMetadata:
+        4de3615de4e17a52204267aa491eece5e2bf262b7e206e575629192e29905484:
+          model: mistralai/mixtral-8x7b-instruct-v0.1
+          release: 1.12.0
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 8746b88809968532d4e89e87a889301feb51db53963c629d5c8641f25cab7ef8
+            number_of_gpus: '1'
+            pp: '1'
+            precision: bf16
+            profile: latency
+            tp: '1'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: LATENCY
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.12.0
+      - key: DOWNLOAD SIZE
+        value: 87GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v0-1:hf-a60832c-tool-use-v2-rtx6000_blackwell_sv__4
+      framework: TensorRT-LLM
+      displayName: Mixtral 8x7b Instruct V0.1 RTX6000_BLACKWELL_SVx1 BF16 Throughput
+      ngcMetadata:
+        ffb72dbc582c757889db80e92ff451fbb41b7e2e282095011570664203059860:
+          model: mistralai/mixtral-8x7b-instruct-v0.1
+          release: 1.12.0
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: f3cadd31e5c7952a0e0240064b0a5d92eec6807465cc361c823f182252cd5e76
+            number_of_gpus: '1'
+            pp: '1'
+            precision: bf16
+            profile: throughput
+            tp: '1'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: THROUGHPUT
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.12.0
+      - key: DOWNLOAD SIZE
+        value: 87GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v0-1:hf-a60832c-tool-use-v2-rtx6000_blackwell_sv__3
+      framework: TensorRT-LLM
+      displayName: Mixtral 8x7b Instruct V0.1 RTX6000_BLACKWELL_SVx1 FP8 Latency
+      ngcMetadata:
+        eb79c173819637a1b1c609f26b732082affb7825871d5a6ba39eaa5ec516d18f:
+          model: mistralai/mixtral-8x7b-instruct-v0.1
+          release: 1.12.0
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 150c4a7f8276d0eeb355246dc21158e063c51d61015b972d77aed5189d9a62ec
+            number_of_gpus: '2'
+            pp: '1'
+            precision: fp8
+            profile: latency
+            tp: '1'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: LATENCY
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.12.0
+      - key: DOWNLOAD SIZE
+        value: 87GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v0-1:hf-a60832c-tool-use-v2-rtx6000_blackwell_sv__2
+      framework: TensorRT-LLM
+      displayName: Mixtral 8x7b Instruct V0.1 RTX6000_BLACKWELL_SVx1 FP8 Throughput
+      ngcMetadata:
+        9aa79b2cd14b16a6960827e7ec013a024d6236e6927ea63b276c7a4dc3b72964:
+          model: mistralai/mixtral-8x7b-instruct-v0.1
+          release: 1.12.0
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 1488c81eba6320033b07ded410dd4a688968e7233608309e434678488ab533f3
+            number_of_gpus: '2'
+            pp: '1'
+            precision: fp8
+            profile: throughput
+            tp: '1'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: THROUGHPUT
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.12.0
+      - key: DOWNLOAD SIZE
+        value: 87GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v0-1:hf-a60832c-tool-use-v2-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Mixtral 8x7b Instruct V0.1 RTX6000_BLACKWELL_SVx2 BF16
+      ngcMetadata:
+        3d73091fd6b66d810cbb9dd011fd842d2a1482a02258ff05f31cd9b00d91f3db:
+          model: mistralai/mixtral-8x7b-instruct-v0.1
+          release: 1.12.0
+          tags:
+            feat_lora: 'true'
+            feat_lora_max_rank: '32'
+            llm_engine: vllm
+            nim_workspace_hash_v1: 1143086cd34eaa9e23556534ece80597734ec4653acf4ed38fc87f993b235371
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 1.12.0
+      - key: DOWNLOAD SIZE
+        value: 87GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v0-1:hf-a60832c-tool-use-v2-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Mixtral 8x7b Instruct V0.1 RTX6000_BLACKWELL_SVx4 BF16
+      ngcMetadata:
+        dd8ce8a7f1a9025f007275f451a6e8b289f4e7b4fea07ac9664ad04b10d1e030:
+          model: mistralai/mixtral-8x7b-instruct-v0.1
+          release: 1.12.0
+          tags:
+            feat_lora: 'true'
+            feat_lora_max_rank: '32'
+            llm_engine: vllm
+            nim_workspace_hash_v1: 1143086cd34eaa9e23556534ece80597734ec4653acf4ed38fc87f993b235371
+            pp: '1'
+            precision: bf16
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 1.12.0
+      - key: DOWNLOAD SIZE
+        value: 87GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v0-1:hf-a60832c-tool-use-v2-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Mixtral 8x7b Instruct V0.1 RTX6000_BLACKWELL_SVx8 BF16
+      ngcMetadata:
+        b85a412ddf8383e654e9be84de4a2697b5096e5e0f9ca33b43bd1d61968552e8:
+          model: mistralai/mixtral-8x7b-instruct-v0.1
+          release: 1.12.0
+          tags:
+            feat_lora: 'true'
+            feat_lora_max_rank: '32'
+            llm_engine: vllm
+            nim_workspace_hash_v1: 1143086cd34eaa9e23556534ece80597734ec4653acf4ed38fc87f993b235371
+            pp: '1'
+            precision: bf16
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 1.12.0
+      - key: DOWNLOAD SIZE
+        value: 87GB
+      - key: LLM ENGINE
+        value: VLLM
   labels:
   - Mistral
   - Instruct

--- a/models/public/1.59.0/nemotron-3-nano.yaml
+++ b/models/public/1.59.0/nemotron-3-nano.yaml
@@ -2242,6 +2242,366 @@ models:
         value: 19GB
       - key: LLM ENGINE
         value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-52469ad-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx1 BF16
+      ngcMetadata:
+        352d88f8021d0ce396a61d10e929d1d4b45f75038b593595d0d92f80a398a032:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '63.0'
+            pp: '1'
+            precision: bf16
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 59GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-fp8-f25a17a-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx1 FP8
+      ngcMetadata:
+        8c91cce84b9b032ff4af489cb1a20395e223af35623010df9155390ab2284b7a:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '34.0'
+            pp: '1'
+            precision: fp8
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 31GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-nvfp4-bd1ffb1-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx1 NVFP4
+      ngcMetadata:
+        1fba9ecfcfb4cde28d4ce3fd55c40bca89a5a613e25e98f057befe6a7e99eada:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '21.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 19GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-52469ad-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx2 BF16
+      ngcMetadata:
+        004cb37f8eab12f30a94f183e0d9b0b1ab2858b17ab80de45138644c2e7007c1:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '34.0'
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 59GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-fp8-f25a17a-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx2 FP8
+      ngcMetadata:
+        49b534e3f90332a7af2d5c9932056e4482ce15fdfe19a596dfd9d662c63309ac:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '19.0'
+            pp: '1'
+            precision: fp8
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 31GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-nvfp4-bd1ffb1-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx2 NVFP4
+      ngcMetadata:
+        c7c492a20a88cb3ca9617f5de293ffabc6f382acd0e57daab70f8cf8f659231c:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '13.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 19GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-52469ad-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx4 BF16
+      ngcMetadata:
+        7c15a5935e32cad80808a37dbb3bb8de4e3eb8231eec55842866d4cfa11db426:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '19.0'
+            pp: '1'
+            precision: bf16
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 59GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-fp8-f25a17a-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx4 FP8
+      ngcMetadata:
+        9412ea9de9fdffb496984fc03b83a95f10e8d23cd019253f60283a7beeaf6a15:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '12.0'
+            pp: '1'
+            precision: fp8
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 31GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-nvfp4-bd1ffb1-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx4 NVFP4
+      ngcMetadata:
+        f49cfb0dd09f937b0515b57b5439c72694059c34af07281b41f1a83f438cbd20:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '9.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 19GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-52469ad-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx8 BF16
+      ngcMetadata:
+        2b28b859b310b857ac6cf272d42a2c984995ba0266f78725f4e26f73eb8ee5ba:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '12.0'
+            pp: '1'
+            precision: bf16
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 59GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-fp8-f25a17a-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx8 FP8
+      ngcMetadata:
+        12f8f7295a37cd1a9b6a3559b0d7449f6ca42ee7b5007de62208385ca1d75d0b:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '8.0'
+            pp: '1'
+            precision: fp8
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 31GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-nvfp4-bd1ffb1-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx8 NVFP4
+      ngcMetadata:
+        b5654c68ac107bc904007487ffe71ede6cb9a560e281929377b623d678f613b6:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '7.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 19GB
+      - key: LLM ENGINE
+        value: VLLM
   labels:
   - Chatbots
   - Virtual Assistants

--- a/models/public/1.59.0/nemotron-3-super-120b-a12b.yaml
+++ b/models/public/1.59.0/nemotron-3-super-120b-a12b.yaml
@@ -1698,6 +1698,366 @@ models:
         value: 75GB
       - key: LLM ENGINE
         value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-bf16-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx1 BF16
+      ngcMetadata:
+        9489f6f6de7ac7c9571b123c30b47a89e80b7881882d3124ab811388d7426ddb:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '237.0'
+            pp: '1'
+            precision: bf16
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 231GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-fp8-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx1 FP8
+      ngcMetadata:
+        5a1a326f51f49bebc8b6e374b1a71e242169e5eb88ef34ab781d0109c7eb7768:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '125.0'
+            pp: '1'
+            precision: fp8
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 120GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-nvfp4-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx1 NVFP4
+      ngcMetadata:
+        3b37a659a22c9390abe7b16aeb29c301c2e9c0e12e5b0fa76171681df31930e0:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '80.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 75GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-bf16-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx2 BF16
+      ngcMetadata:
+        37fe705735f5e860db323d70e43a6e31d1274ba4cf92401c8f3ff7e8a84f093c:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '121.0'
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 231GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-fp8-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx2 FP8
+      ngcMetadata:
+        57d42cc7d33914933427e7f8d8cb1773bc11e5c96826c92095820a8776e6a4f6:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '65.0'
+            pp: '1'
+            precision: fp8
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 120GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-nvfp4-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx2 NVFP4
+      ngcMetadata:
+        7cbcde87a4f6ae47e4ed6a12d236e84672f718a418b3eeb66b1249dec74c7109:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '42.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 75GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-bf16-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx4 BF16
+      ngcMetadata:
+        2f4c50e34aec6bc548c85c8341eda99896c990dd777efb2afc658ecec6f08e30:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '63.0'
+            pp: '1'
+            precision: bf16
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 231GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-fp8-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx4 FP8
+      ngcMetadata:
+        2ed42dc23f8e95f1fc0d2b50658a309344c3892bb99eea5c992679084a3ad52f:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '35.0'
+            pp: '1'
+            precision: fp8
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 120GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-nvfp4-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx4 NVFP4
+      ngcMetadata:
+        d08504a72861c984173b37188d78c7150a69570afdc56ca5a585edc9226115e2:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '24.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 75GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-bf16-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx8 BF16
+      ngcMetadata:
+        4a05267a2849aa326117676f55ae1a436e3a59f275d4c4e8ea8fed2190b5dea6:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '35.0'
+            pp: '1'
+            precision: bf16
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 231GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-fp8-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx8 FP8
+      ngcMetadata:
+        5791516f97ec7c748456aebee86f8bb9ce618dab40055a71ab40852c09787a4c:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '21.0'
+            pp: '1'
+            precision: fp8
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 120GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-nvfp4-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx8 NVFP4
+      ngcMetadata:
+        f8aa408323c38e25046ee87549a5847d666d02de45a029a40b34719dd3fb88c9:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '15.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 75GB
+      - key: LLM ENGINE
+        value: VLLM
   labels:
   - Chatbots
   - Virtual Assistants

--- a/models/public/1.59.0/nemotron-nano-12b-v2-vl.yaml
+++ b/models/public/1.59.0/nemotron-nano-12b-v2-vl.yaml
@@ -649,6 +649,66 @@ models:
         value: 15GB
       - key: LLM ENGINE
         value: VLLM
+    - profileId: nim/nvidia/nemotron-nano-12b-v2-vl:1.5.0-bf16-hf-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Nemotron Nano 12B V2 Vl RTX6000_BLACKWELL_SVx1 BF16
+      ngcMetadata:
+        06a217a1099a72e5d86a12a31fd39eaba9d7c00d3d311589557d2dc720b59358:
+          model: nvidia/nemotron-nano-12b-v2-vl
+          release: 1.5.0
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            nim_workspace_hash_v1: d943a0e2491f1abaae2e3c2532bc3b70535b0d8637d7b1aeed4e686f0e3e0f61
+            pp: '1'
+            precision: bf16
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 1.5.0
+      - key: DOWNLOAD SIZE
+        value: 25GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-nano-12b-v2-vl:1.5.0-bf16-hf-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Nemotron Nano 12B V2 Vl RTX6000_BLACKWELL_SVx2 BF16
+      ngcMetadata:
+        97aae95b218c9838fea29548ebaa771a922a8c9781c8450e542e323e2a76a937:
+          model: nvidia/nemotron-nano-12b-v2-vl
+          release: 1.5.0
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            nim_workspace_hash_v1: d943a0e2491f1abaae2e3c2532bc3b70535b0d8637d7b1aeed4e686f0e3e0f61
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 1.5.0
+      - key: DOWNLOAD SIZE
+        value: 25GB
+      - key: LLM ENGINE
+        value: VLLM
   labels:
   - Multimodal Vision Language Model
   - Visual Reasoning

--- a/models/public/1.59.0/nemotron-parse.yaml
+++ b/models/public/1.59.0/nemotron-parse.yaml
@@ -85,6 +85,70 @@ models:
         value: TENSORRT_LLM
       - key: TRTLLM BUILDABLE
         value: 'TRUE'
+    - profileId: nim/nvidia/nemotron-parse:hf-v5-b100
+      framework: TensorRT-LLM
+      displayName: Nemotron Parse B100x1 BF16
+      ngcMetadata:
+        a3d5f5727f27e898fc27658d0c11ff97a7de9edeff6c6065c2c838906f00dbd6:
+          model: nvidia/nemotron-parse
+          release: 1.5.0
+          tags:
+            llm_engine: tensorrt_llm
+            pp: '1'
+            precision: bf16
+            tllm_engine_config_json_str: '{"max_batch_size": 32}'
+            tp: '1'
+            trtllm_buildable: 'true'
+            gpu: B100
+            gpu_device: ''
+      modelFormat: trt-llm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: B100
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 1.5.0
+      - key: DOWNLOAD SIZE
+        value: 4GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+      - key: TRTLLM BUILDABLE
+        value: 'TRUE'
+    - profileId: nim/nvidia/nemotron-parse:hf-v5-b200
+      framework: TensorRT-LLM
+      displayName: Nemotron Parse B200x1 BF16
+      ngcMetadata:
+        a3d5f5727f27e898fc27658d0c11ff97a7de9edeff6c6065c2c838906f00dbd6:
+          model: nvidia/nemotron-parse
+          release: 1.5.0
+          tags:
+            llm_engine: tensorrt_llm
+            pp: '1'
+            precision: bf16
+            tllm_engine_config_json_str: '{"max_batch_size": 32}'
+            tp: '1'
+            trtllm_buildable: 'true'
+            gpu: B200
+            gpu_device: ''
+      modelFormat: trt-llm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: B200
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 1.5.0
+      - key: DOWNLOAD SIZE
+        value: 4GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+      - key: TRTLLM BUILDABLE
+        value: 'TRUE'
     - profileId: nim/nvidia/nemotron-parse:hf-v5-h100
       framework: TensorRT-LLM
       displayName: Nemotron Parse H100x1 BF16
@@ -179,6 +243,38 @@ models:
         value: 1
       - key: GPU DEVICE
         value: 26B9:10DE
+      - key: NIM VERSION
+        value: 1.5.0
+      - key: DOWNLOAD SIZE
+        value: 4GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+      - key: TRTLLM BUILDABLE
+        value: 'TRUE'
+    - profileId: nim/nvidia/nemotron-parse:hf-v5-rtx6000_blackwell_sv
+      framework: TensorRT-LLM
+      displayName: Nemotron Parse RTX6000_BLACKWELL_SVx1 BF16
+      ngcMetadata:
+        a3d5f5727f27e898fc27658d0c11ff97a7de9edeff6c6065c2c838906f00dbd6:
+          model: nvidia/nemotron-parse
+          release: 1.5.0
+          tags:
+            llm_engine: tensorrt_llm
+            pp: '1'
+            precision: bf16
+            tllm_engine_config_json_str: '{"max_batch_size": 32}'
+            tp: '1'
+            trtllm_buildable: 'true'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: trt-llm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
       - key: NIM VERSION
         value: 1.5.0
       - key: DOWNLOAD SIZE

--- a/models/public/1.59.0/starcoder-2.yaml
+++ b/models/public/1.59.0/starcoder-2.yaml
@@ -122,6 +122,138 @@ models:
         value: TENSORRT_LLM
       - key: TRTLLM BUILDABLE
         value: 'TRUE'
+    - profileId: nim/bigcode/starcoder2-7b:hf-bb9afde-b100
+      framework: TensorRT-LLM
+      displayName: Starcoder2 7B B100x1 BF16
+      ngcMetadata:
+        de71c59001bc42679b37ecddfd95ab7b759cfde4308071750dcf5e3558726c9b:
+          model: bigcode/starcoder2-7b
+          release: 1.15.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 43ab4fbb30e1beedda3de8df4244c9fc44fb8fbd8ba0ac23b028abf822bbf637
+            pp: '1'
+            precision: bf16
+            tp: '1'
+            trtllm_buildable: 'true'
+            gpu: B100
+            gpu_device: ''
+      modelFormat: trt-llm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: B100
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 1.15.3
+      - key: DOWNLOAD SIZE
+        value: 14GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+      - key: TRTLLM BUILDABLE
+        value: 'TRUE'
+    - profileId: nim/bigcode/starcoder2-7b:hf-bb9afde-b100-tp2
+      framework: TensorRT-LLM
+      displayName: Starcoder2 7B B100x2 BF16
+      ngcMetadata:
+        fe652f0f0ef911e255f1ff710d522d112ffda7856fe58824a9a5ef963960c909:
+          model: bigcode/starcoder2-7b
+          release: 1.15.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 43ab4fbb30e1beedda3de8df4244c9fc44fb8fbd8ba0ac23b028abf822bbf637
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            trtllm_buildable: 'true'
+            gpu: B100
+            gpu_device: ''
+      modelFormat: trt-llm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: B100
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 1.15.3
+      - key: DOWNLOAD SIZE
+        value: 14GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+      - key: TRTLLM BUILDABLE
+        value: 'TRUE'
+    - profileId: nim/bigcode/starcoder2-7b:hf-bb9afde-b200
+      framework: TensorRT-LLM
+      displayName: Starcoder2 7B B200x1 BF16
+      ngcMetadata:
+        de71c59001bc42679b37ecddfd95ab7b759cfde4308071750dcf5e3558726c9b:
+          model: bigcode/starcoder2-7b
+          release: 1.15.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 43ab4fbb30e1beedda3de8df4244c9fc44fb8fbd8ba0ac23b028abf822bbf637
+            pp: '1'
+            precision: bf16
+            tp: '1'
+            trtllm_buildable: 'true'
+            gpu: B200
+            gpu_device: ''
+      modelFormat: trt-llm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: B200
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 1.15.3
+      - key: DOWNLOAD SIZE
+        value: 14GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+      - key: TRTLLM BUILDABLE
+        value: 'TRUE'
+    - profileId: nim/bigcode/starcoder2-7b:hf-bb9afde-b200-tp2
+      framework: TensorRT-LLM
+      displayName: Starcoder2 7B B200x2 BF16
+      ngcMetadata:
+        fe652f0f0ef911e255f1ff710d522d112ffda7856fe58824a9a5ef963960c909:
+          model: bigcode/starcoder2-7b
+          release: 1.15.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 43ab4fbb30e1beedda3de8df4244c9fc44fb8fbd8ba0ac23b028abf822bbf637
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            trtllm_buildable: 'true'
+            gpu: B200
+            gpu_device: ''
+      modelFormat: trt-llm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: B200
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 1.15.3
+      - key: DOWNLOAD SIZE
+        value: 14GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+      - key: TRTLLM BUILDABLE
+        value: 'TRUE'
     - profileId: nim/bigcode/starcoder2-7b:hf-bb9afde-h100
       framework: TensorRT-LLM
       displayName: Starcoder2 7B H100x1 BF16
@@ -540,6 +672,72 @@ models:
         value: 2
       - key: GPU DEVICE
         value: 26B9:10DE
+      - key: NIM VERSION
+        value: 1.15.3
+      - key: DOWNLOAD SIZE
+        value: 14GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+      - key: TRTLLM BUILDABLE
+        value: 'TRUE'
+    - profileId: nim/bigcode/starcoder2-7b:hf-bb9afde-rtx6000_blackwell_sv
+      framework: TensorRT-LLM
+      displayName: Starcoder2 7B RTX6000_BLACKWELL_SVx1 BF16
+      ngcMetadata:
+        de71c59001bc42679b37ecddfd95ab7b759cfde4308071750dcf5e3558726c9b:
+          model: bigcode/starcoder2-7b
+          release: 1.15.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 43ab4fbb30e1beedda3de8df4244c9fc44fb8fbd8ba0ac23b028abf822bbf637
+            pp: '1'
+            precision: bf16
+            tp: '1'
+            trtllm_buildable: 'true'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: trt-llm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 1.15.3
+      - key: DOWNLOAD SIZE
+        value: 14GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+      - key: TRTLLM BUILDABLE
+        value: 'TRUE'
+    - profileId: nim/bigcode/starcoder2-7b:hf-bb9afde-rtx6000_blackwell_sv-tp2
+      framework: TensorRT-LLM
+      displayName: Starcoder2 7B RTX6000_BLACKWELL_SVx2 BF16
+      ngcMetadata:
+        fe652f0f0ef911e255f1ff710d522d112ffda7856fe58824a9a5ef963960c909:
+          model: bigcode/starcoder2-7b
+          release: 1.15.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 43ab4fbb30e1beedda3de8df4244c9fc44fb8fbd8ba0ac23b028abf822bbf637
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            trtllm_buildable: 'true'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: trt-llm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
       - key: NIM VERSION
         value: 1.15.3
       - key: DOWNLOAD SIZE

--- a/models/public/cosmos-reason2-8b.yaml
+++ b/models/public/cosmos-reason2-8b.yaml
@@ -534,6 +534,35 @@ models:
         value: 10GB
       - key: LLM ENGINE
         value: VLLM
+    - profileId: nim/nvidia/cosmos-reason2-8b:hf-0303-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Cosmos Reason2 8B RTX6000_BLACKWELL_SVx1 BF16
+      ngcMetadata:
+        438f4f3c69868f7755b07d0a0e03396f2c8862a570e4603572578785b137d1c3:
+          model: nvidia/cosmos-reason2-8b
+          release: '1.7.0'
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            nim_workspace_hash_v1: e905c7b3c8f807e05968ea232cda81e59f27545f1a24e07edad14d003935ee13
+            precision: bf16
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: '1.7.0'
+      - key: DOWNLOAD SIZE
+        value: 17GB
+      - key: LLM ENGINE
+        value: VLLM
   labels:
   - Multimodal
   - Vision-Language

--- a/models/public/gpt-oss.yaml
+++ b/models/public/gpt-oss.yaml
@@ -801,6 +801,126 @@ models:
         value: 13GB
       - key: LLM ENGINE
         value: VLLM
+    - profileId: nim/openai/gpt-oss-20b:hf-d666cf3-nim-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: GPT-OSS 20B RTX6000_BLACKWELL_SVx1 MXFP4
+      ngcMetadata:
+        66fb3113efd2aae1b0a3bfa2a375de5fe1cc1b557abac4eb271730482a26ae8e:
+          model: openai/gpt-oss-20b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            nim_workspace_hash_v1: bef4d428df8c3e67ebe56ba2050a0f50216e82c0172407b43c99c1f6befc9fc5
+            pp: '1'
+            precision: mxfp4
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: MXFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 13GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/openai/gpt-oss-20b:hf-d666cf3-nim-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: GPT-OSS 20B RTX6000_BLACKWELL_SVx2 MXFP4
+      ngcMetadata:
+        c3035169e189674226b284a07173f495b6ce13f2a06d5ea204f1e505c2fac2be:
+          model: openai/gpt-oss-20b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            nim_workspace_hash_v1: bef4d428df8c3e67ebe56ba2050a0f50216e82c0172407b43c99c1f6befc9fc5
+            pp: '1'
+            precision: mxfp4
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: MXFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 13GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/openai/gpt-oss-20b:hf-d666cf3-nim-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: GPT-OSS 20B RTX6000_BLACKWELL_SVx4 MXFP4
+      ngcMetadata:
+        653e98d21f9274306416d736519e1c0442d9dad9d8756ff1134cbededfd43323:
+          model: openai/gpt-oss-20b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            nim_workspace_hash_v1: bef4d428df8c3e67ebe56ba2050a0f50216e82c0172407b43c99c1f6befc9fc5
+            pp: '1'
+            precision: mxfp4
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: MXFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 13GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/openai/gpt-oss-20b:hf-d666cf3-nim-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: GPT-OSS 20B RTX6000_BLACKWELL_SVx8 MXFP4
+      ngcMetadata:
+        66b8ec445352535aa8c640435d6f7b00fb2cabb70f8d39fc371adb00322907df:
+          model: openai/gpt-oss-20b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            nim_workspace_hash_v1: bef4d428df8c3e67ebe56ba2050a0f50216e82c0172407b43c99c1f6befc9fc5
+            pp: '1'
+            precision: mxfp4
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: MXFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 13GB
+      - key: LLM ENGINE
+        value: VLLM
   - variantId: GPT-OSS 120B
     modelCard: ewogICAgImFjY2Vzc1R5cGUiOiAiTk9UX0xJU1RFRCIsCiAgICAiYXBwbGljYXRpb24iOiAiT3RoZXIiLAogICAgImJpYXMiOiAiIiwKICAgICJjYW5HdWVzdERvd25sb2FkIjogZmFsc2UsCiAgICAiY3JlYXRlZERhdGUiOiAiMjAyNS0wOC0wNVQxOTozNzowNi4zMzBaIiwKICAgICJkZXNjcmlwdGlvbiI6ICIjIEdQVCBPU1MgMTIwQiBPdmVydmlld1xuXG4jIyBEZXNjcmlwdGlvbjogPGJyPlxuT3BlbkFJIHJlbGVhc2VzIHRoZSBncHQtb3NzIGZhbWlseSBvZiBvcGVuLXdlaWdodCBtb2RlbHMgZGVzaWduZWQgZm9yIHBvd2VyZnVsIHJlYXNvbmluZywgYWdlbnRpYyB0YXNrcywgYW5kIHZlcnNhdGlsZSBkZXZlbG9wZXIgdXNlIGNhc2VzLiBUaGUgZmFtaWx5IGNvbnNpc3RzIG9mIHRoZTpcbi0gYGdwdC1vc3MtMTIwYmAgXHUyMDE0IGZvciBwcm9kdWN0aW9uLCBnZW5lcmFsIHB1cnBvc2UsIGhpZ2ggcmVhc29uaW5nIHVzZS1jYXNlcyB0aGF0IGZpdHMgaW50byBhIHNpbmdsZSBIMTAwIEdQVSAoMTE3QiBwYXJhbWV0ZXJzIHdpdGggNS4xQiBhY3RpdmUgcGFyYW1ldGVycylcbi0gYGdwdC1vc3MtMjBiYCBcdTIwMTQgZm9yIGxvd2VyIGxhdGVuY3ksIGFuZCBsb2NhbCBvciBzcGVjaWFsaXplZCB1c2UtY2FzZXMgKDIxQiBwYXJhbWV0ZXJzIHdpdGggMy42QiBhY3RpdmUgcGFyYW1ldGVycykuXG5cblRoZSBgZ3B0LW9zcy0xMjBiYCBtb2RlbCBpcyBhcmNoaXRlY3R1cmFsbHkgZGVzaWduZWQgYXMgYSBNaXh0dXJlLW9mLUV4cGVydHMgKE1vRSkgbW9kZWwuIFRoaXMgbW9kZWwgZmVhdHVyZXMgU3dpR0xVIGFjdGl2YXRpb25zIGFuZCBsZWFybmVkIGF0dGVudGlvbiBzaW5rcyB3aXRoaW4gaXRzIGFyY2hpdGVjdHVyZS4gSXQgZnVuY3Rpb25zIGFzIGEgcmVhc29uaW5nIG1vZGVsLCBzdXBwb3J0aW5nIGNhcGFiaWxpdGllcyBzdWNoIGFzIGNoYWluLW9mLXRob3VnaHQgcHJvY2Vzc2luZywgYWRqdXN0YWJsZSByZWFzb25pbmcgZWZmb3J0IGxldmVscywgaW5zdHJ1Y3Rpb24gZm9sbG93aW5nLCBhbmQgdG9vbCB1c2UuIFRoaXMgbW9kZWwgaXMgdGV4dC1vbmx5IGZvciBib3RoIGlucHV0IGFuZCBvdXRwdXQgbW9kYWxpdGllcywgZW5hYmxpbmcgZW50ZXJwcmlzZXMgYW5kIGdvdmVybm1lbnRzIHRvIGRlcGxveSBpdCBvbi1wcmVtaXNlcyBvciBpbiBwcml2YXRlIGNsb3VkIGVudmlyb25tZW50cyBmb3IgZW5oYW5jZWQgZGF0YSBzZWN1cml0eSBhbmQgcHJpdmFjeS5cblxuTW9kZWwgSGlnaGxpZ2h0czogIFxuLSAqKlBlcm1pc3NpdmUgQXBhY2hlIDIuMCBsaWNlbnNlOioqIEJ1aWxkIGZyZWVseSB3aXRob3V0IGNvcHlsZWZ0IHJlc3RyaWN0aW9ucyBvciBwYXRlbnQgcmlza1x1MjAxNGlkZWFsIGZvciBleHBlcmltZW50YXRpb24sIGN1c3RvbWl6YXRpb24sIGFuZCBjb21tZXJjaWFsIGRlcGxveW1lbnQuXG4tICoqQ29uZmlndXJhYmxlIHJlYXNvbmluZyBlZmZvcnQ6KiogRWFzaWx5IGFkanVzdCB0aGUgcmVhc29uaW5nIGVmZm9ydCAobG93LCBtZWRpdW0sIGhpZ2gpIGJhc2VkIG9uIHlvdXIgc3BlY2lmaWMgdXNlIGNhc2UgYW5kIGxhdGVuY3kgbmVlZHMuXG4tICoqRnVsbCBjaGFpbi1vZi10aG91Z2h0OioqIEdhaW4gY29tcGxldGUgYWNjZXNzIHRvIHRoZSBtb2RlbCdzIHJlYXNvbmluZyBwcm9jZXNzLCBmYWNpbGl0YXRpbmcgZWFzaWVyIGRlYnVnZ2luZyBhbmQgaW5jcmVhc2VkIHRydXN0IGluIG91dHB1dHMuIEl0J3Mgbm90IGludGVuZGVkIHRvIGJlIHNob3duIHRvIGVuZCB1c2Vycy5cbi0gKipGaW5lLXR1bmFibGU6KiogRnVsbHkgY3VzdG9taXplIG1vZGVscyB0byB5b3VyIHNwZWNpZmljIHVzZSBjYXNlIHRocm91Z2ggcGFyYW1ldGVyIGZpbmUtdHVuaW5nLlxuLSAqKkFnZW50aWMgY2FwYWJpbGl0aWVzOioqIFVzZSB0aGUgbW9kZWxzJyBuYXRpdmUgY2FwYWJpbGl0aWVzIGZvciBmdW5jdGlvbiBjYWxsaW5nLCB3ZWIgYnJvd3NpbmcsIHB5dGhvbiBjb2RlIGV4ZWN1dGlvbiwgYW5kIHN0cnVjdHVyZWQgb3V0cHV0cy5cblxuVGhpcyBtb2RlbCBpcyByZWFkeSBmb3IgY29tbWVyY2lhbC9ub24tY29tbWVyY2lhbCB1c2UuXG5cblxuIyMgVGhpcmQtUGFydHkgQ29tbXVuaXR5IENvbnNpZGVyYXRpb24gPGJyPlxuVGhpcyBtb2RlbCBpcyBub3Qgb3duZWQgb3IgZGV2ZWxvcGVkIGJ5IE5WSURJQS4gVGhpcyBtb2RlbCBoYXMgYmVlbiBkZXZlbG9wZWQgYW5kIGJ1aWx0IHRvIGEgdGhpcmQtcGFydHlcdTIwMTlzIHJlcXVpcmVtZW50cyBmb3IgdGhpcyBhcHBsaWNhdGlvbiBhbmQgdXNlIGNhc2U7IHNlZSBsaW5rIHRvIE5vbi1OVklESUEgW2dwdC1vc3MtMTIwYiBtb2RlbCBjYXJkXShodHRwczovL2h1Z2dpbmdmYWNlLmNvL29wZW5haS9ncHQtb3NzLTEyMGIpLlxuXG5cbiMjIyBMaWNlbnNlIGFuZCBUZXJtcyBvZiBVc2U6IDxicj5cbkdPVkVSTklORyBURVJNUzogVGhlIE5JTSBjb250YWluZXIgaXMgZ292ZXJuZWQgYnkgdGhlIFtOVklESUEgU29mdHdhcmUgTGljZW5zZSBBZ3JlZW1lbnRdKGF0IGh0dHBzOi8vd3d3Lm52aWRpYS5jb20vZW4tdXMvYWdyZWVtZW50cy9lbnRlcnByaXNlLXNvZnR3YXJlL252aWRpYS1zb2Z0d2FyZS1saWNlbnNlLWFncmVlbWVudC8pIGFuZCB0aGUgW1Byb2R1Y3QtU3BlY2lmaWMgVGVybXMgZm9yIE5WSURJQSBBSSBQcm9kdWN0c10oaHR0cHM6Ly93d3cubnZpZGlhLmNvbS9lbi11cy9hZ3JlZW1lbnRzL2VudGVycHJpc2Utc29mdHdhcmUvcHJvZHVjdC1zcGVjaWZpYy10ZXJtcy1mb3ItYWktcHJvZHVjdHMvKTsgYW5kIHRoZSB1c2Ugb2YgdGhpcyBtb2RlbCBpcyBnb3Zlcm5lZCBieSB0aGUgW05WSURJQSBDb21tdW5pdHkgTW9kZWwgTGljZW5zZSBBZ3JlZW1lbnRdKGh0dHBzOi8vd3d3Lm52aWRpYS5jb20vZW4tdXMvYWdyZWVtZW50cy9lbnRlcnByaXNlLXNvZnR3YXJlL252aWRpYS1jb21tdW5pdHktbW9kZWxzLWxpY2Vuc2UvKS5cbkFkZGl0aW9uYWwgSW5mb3JtYXRpb246IFtBcGFjaGUgTGljZW5zZSBWZXJzaW9uIDIuMF0oaHR0cHM6Ly93d3cuYXBhY2hlLm9yZy9saWNlbnNlcy9MSUNFTlNFLTIuMCkuXG5cbioqWW91IGFyZSByZXNwb25zaWJsZSBmb3IgZW5zdXJpbmcgdGhhdCB5b3VyIHVzZSBvZiBOVklESUEgcHJvdmlkZWQgbW9kZWxzIGNvbXBsaWVzIHdpdGggYWxsIGFwcGxpY2FibGUgbGF3cyoqXG5cbiMjIEdldCBIZWxwXG5cbiMjIyBFbnRlcnByaXNlIFN1cHBvcnRcblxuR2V0IGFjY2VzcyB0byBrbm93bGVkZ2UgYmFzZSBhcnRpY2xlcyBhbmQgc3VwcG9ydCBjYXNlcyBvciBbc3VibWl0IGEgdGlja2V0XShodHRwczovL3d3dy5udmlkaWEuY29tL2VuLXVzL2RhdGEtY2VudGVyL3Byb2R1Y3RzL2FpLWVudGVycHJpc2Utc3VpdGUvc3VwcG9ydC8pLlxuXG4jIyMgTlZJRElBIE5JTSBEb2N1bWVudGF0aW9uXG5cblZpc2l0IHRoZSBbTklNIENvbnRhaW5lciBMTE1dKGh0dHBzOi8vZG9jcy5udmlkaWEuY29tL25pbS9sYXJnZS1sYW5ndWFnZS1tb2RlbHMvbGF0ZXN0L2ludHJvZHVjdGlvbi5odG1sKSBwYWdlIGZvciByZWxlYXNlIGRvY3VtZW50YXRpb24sIGRlcGxveW1lbnQgZ3VpZGVzIGFuZCBtb3JlLlxuXG4jIyMgRGVwbG95bWVudCBHZW9ncmFwaHk6XG5HbG9iYWxcblxuIyMjIFVzZSBDYXNlOiA8YnI+XG5JbnRlbmRlZCBmb3IgdXNlIGFzIGEgcmVhc29uaW5nIG1vZGVsIHdpdGggZmVhdHVyZXMgbGlrZSBjaGFpbi1vZi10aG91Z2h0IGFuZCBhZGp1c3RhYmxlIHJlYXNvbmluZyBlZmZvcnQgbGV2ZWxzLiBJdCBzdXBwb3J0cyBpbnN0cnVjdGlvbiBmb2xsb3dpbmcgYW5kIHRvb2wgdXNlLCBvZmZlcmluZyB0cmFuc3BhcmVuY3ksIGN1c3RvbWl6YXRpb24sIGFuZCBkZXBsb3ltZW50IGZsZXhpYmlsaXR5IGZvciBkZXZlbG9wZXJzLCByZXNlYXJjaGVycywgYW5kIHN0YXJ0dXBzLiBBZGRpdGlvbmFsbHksIGl0IGVuYWJsZXMgZW50ZXJwcmlzZXMgYW5kIGdvdmVybm1lbnRzIHRvIGRlcGxveSBvbi1wcmVtaXNlcyBvciBpbiBwcml2YXRlIGNsb3VkcyB0byBlbnN1cmUgZGF0YSBzZWN1cml0eSBhbmQgcHJpdmFjeS5cblxuIyMjIFJlbGVhc2UgRGF0ZTogIDxicj5cbkJ1aWxkLk5WSURJQS5jb20gLSAwOC8wNS8yMDI1IHZpYSBbbGlua10oaHR0cHM6Ly9idWlsZC5udmlkaWEuY29tL29wZW5haS9ncHQtb3NzLTEyMGIpIDxicj4gXG5IdWdnaW5nIEZhY2UgLSAwOC8wNS8yMDI1IHZpYSBbbGlua10oaHR0cHM6Ly9odWdnaW5nZmFjZS5jby9vcGVuYWkvZ3B0LW9zcy0xMjBiKSA8YnI+XG5cbiMjIFJlZmVyZW5jZShzKTpcbi0gW09wZW5BSSBDb29rYm9va10oaHR0cHM6Ly9jb29rYm9vay5vcGVuYWkuY29tLylcbi0gW09wZW4gQUkgQ29vYmtib29rIC0tIFNlcnZpbmcgTW9kZWwgd2l0aCBUZW5zb3JSVC1MTE1dKGh0dHBzOi8vY29va2Jvb2sub3BlbmFpLmNvbS9hcnRpY2xlcy9ncHQtb3NzL3J1bi1udmlkaWEpXG5cblxuIyMgTW9kZWwgQXJjaGl0ZWN0dXJlOiA8YnI+IFxuKipBcmNoaXRlY3R1cmUgVHlwZToqKiBUcmFuc2Zvcm1lciA8YnI+XG4qKk5ldHdvcmsgQXJjaGl0ZWN0dXJlOioqIE1peHR1cmUtb2YtRXhwZXJ0cyAoTW9FKSA8YnI+XG4qKlRvdGFsIFBhcmFtZXRlcnM6KiogMTE3QiA8YnI+XG4qKkFjdGl2ZSBQYXJhbWV0ZXJzOioqIDUuN0IgPGJyPlxuKipWb2NhYnVsYXJ5IFNpemU6KiogMjAxLDA4OCA8YnI+XG5cblxuIyMgSW5wdXQ6IDxicj5cbioqSW5wdXQgVHlwZShzKToqKiBUZXh0IDxicj5cbioqSW5wdXQgRm9ybWF0KHMpOioqIFN0cmluZyA8YnI+XG4qKklucHV0IFBhcmFtZXRlcnM6KiogT25lIERpbWVuc2lvbmFsICgxRCkgPGJyPlxuKipPdGhlciBQcm9wZXJ0aWVzIFJlbGF0ZWQgdG8gSW5wdXQ6KiogVXNlcyBSb1BFIHdpdGggYSAxMjhrIGNvbnRleHQgbGVuZ3RoLCB3aXRoIGF0dGVudGlvbiBsYXllcnMgYWx0ZXJuYXRpbmcgYmV0d2VlbiBmdWxsIGNvbnRleHQgYW5kIGEgc2xpZGluZyAxMjgtdG9rZW4gd2luZG93LiBJbmNsdWRlcyBhIGxlYXJuZWQgYXR0ZW50aW9uIHNpbmsgcGVyLWhlYWQuIEVtcGxveXMgU3dpR0xVIGFjdGl2YXRpb25zIGluIHRoZSBNb0UgbGF5ZXJzLCBhbmQgdGhlIHJvdXRlciBwZXJmb3JtcyBhIFRvcC1LIG9wZXJhdGlvbiAoSz00KSBmb2xsb3dlZCBieSBhIFNpZ21vaWQgZnVuY3Rpb24uIEdFTU1zIGluIHRoZSBNb0UgaW5jbHVkZSBhIHBlci1leHBlcnQgYmlhcy4gVXRpbGl6ZXMgdGlrdG9rZW4gZm9yIHRva2VuaXphdGlvbi4gSW5wdXQgQ29udGV4dCBMZW5ndGggKElTTCk6IDEyODAwMCA8YnI+XG5cbiMjIE91dHB1dDogPGJyPlxuKipPdXRwdXQgVHlwZShzKToqKiBUZXh0IDxicj5cbioqT3V0cHV0IEZvcm1hdDoqKiBTdHJpbmcgPGJyPlxuKipPdXRwdXQgUGFyYW1ldGVyczoqKiBPbmUgRGltZW5zaW9uYWwgKDFEKSA8YnI+XG4qKk90aGVyIFByb3BlcnRpZXMgUmVsYXRlZCB0byBPdXRwdXQ6KiogVGhlIG1vZGVsIGlzIGRlc2lnbmVkIHRvIGJlIGNvbXBhdGlibGUgd2l0aCB0aGUgT3BlbkFJIFJlc3BvbnNlcyBBUEkgYW5kIHN1cHBvcnRzIFN0cnVjdHVyZWQgT3V0cHV0LiA8YnI+IFxuXG5PdXIgQUkgbW9kZWxzIGFyZSBkZXNpZ25lZCBhbmQvb3Igb3B0aW1pemVkIHRvIHJ1biBvbiBOVklESUEgR1BVLWFjY2VsZXJhdGVkIHN5c3RlbXMgW29yIG5hbWUgZXF1aXZhbGVudCBoYXJkd2FyZSBwcmVmZXJlbmNlXS4gQnkgbGV2ZXJhZ2luZyBOVklESUFcdTIwMTlzIGhhcmR3YXJlIChlLmcuIEdQVSBjb3JlcykgYW5kIHNvZnR3YXJlIGZyYW1ld29ya3MgKGUuZy4sIENVREEgbGlicmFyaWVzKSwgdGhlIG1vZGVsIGFjaGlldmVzIGZhc3RlciB0cmFpbmluZyBhbmQgaW5mZXJlbmNlIHRpbWVzIGNvbXBhcmVkIHRvIENQVS1vbmx5IHNvbHV0aW9ucy4gPGJyPiAgIFxuXG4jIyBTb2Z0d2FyZSBJbnRlZ3JhdGlvbjogPGJyPlxuKipSdW50aW1lIEVuZ2luZShzKToqKiA8YnI+XG4qIE5lTW8gRnJhbWV3b3JrIChiYXNlZCBvbiAyNS4wNyk8YnI+XG5cblxuKipTdXBwb3J0ZWQgSGFyZHdhcmUgTWljcm9hcmNoaXRlY3R1cmUgQ29tcGF0aWJpbGl0eToqKiA8YnI+XG4qIE5WSURJQSBCbGFja3dlbGw6IEIyMDAgPGJyPlxuKiBOVklESUEgSG9wcGVyOiBIMjAwXG5cblxuKipPcGVyYXRpbmcgU3lzdGVtKHMpOioqIExpbnV4IFxuXG4jIyBNb2RlbCBWZXJzaW9uKHMpOiBcbmBncHQtb3NzLTEyMGJgIHYxLjAgKEF1Z3VzdCA1LCAyMDI1KVxuXG5cbiMjIFRyYWluaW5nLCBUZXN0aW5nLCBhbmQgRXZhbHVhdGlvbiBEYXRhc2V0czogPGJyPiAgIFxuIyMjIFRyYWluaW5nIERhdGFzZXQ6XG5cbiogKipUcmFpbmluZyBEYXRhIENvbGxlY3Rpb246KiogVW5kaXNjbG9zZWQgPGJyPlxuKiAqKlRyYWluaW5nIExhYmVsaW5nOioqIFVuZGlzY2xvc2VkIDxicj5cbiogKipUcmFpbmluZyBQcm9wZXJ0aWVzOioqIFRoZSBtb2RlbCBoYXMgYXBwcm94aW1hdGVseSAxMTcgYmlsbGlvbiBwYXJhbWV0ZXJzLiBXZWlnaHRzIGZvciBhbGwgbGF5ZXJzIGFyZSBpbiBCRjE2LCBleGNlcHQgZm9yIE1vRSBwcm9qZWN0aW9uIHdlaWdodHMsIHdoaWNoIGFyZSBpbiBNWEZQNC4gVGhlIHJlZmVyZW5jZSBpbXBsZW1lbnRhdGlvbiBjdXJyZW50bHkgdXBjYXN0cyBhbGwgd2VpZ2h0cyB0byBCRjE2LiBBY3RpdmF0aW9ucyBhcmUgZXhwZWN0ZWQgdG8gYmUgaW4gQkYxNiBvciBGUDguXG5cblxuIyMjIFRlc3RpbmcgRGF0YXNldDpcbiogKipUZXN0aW5nIERhdGEgQ29sbGVjdGlvbjoqKiBVbmRpc2Nsb3NlZCA8YnI+XG4qICoqVGVzdGluZyBMYWJlbGluZzoqKiBVbmRpc2Nsb3NlZCA8YnI+XG4qICoqVGVzdGluZyBQcm9wZXJ0aWVzOioqIFRoZSBtb2RlbCBpcyB0ZXN0ZWQgYWdhaW5zdCBiZW5jaG1hcmtzIHN1Y2ggYXMgTU1MVSBhbmQgR1BRQSwgYW1vbmcgb3RoZXJzIGluY2x1ZGluZyBMaXZlQ29kZUJlbmNoLCBBSU1FIDIwMjQsIGFuZCBNQVRILTUwMC4gXG5cbiMjIyBFdmFsdWF0aW9uIERhdGFzZXQ6XG5cbiogKipFdmFsdWF0aW9uIERhdGEgQ29sbGVjdGlvbjoqKiBVbmRpc2Nsb3NlZCA8YnI+XG4qICoqRXZhbHVhdGlvbiBMYWJlbGluZzoqKiBVbmRpc2Nsb3NlZCA8YnI+XG4qICoqRXZhbHVhdGlvbiBCZW5jaG1hcmsgU2NvcmU6KiogXG5cbnwgQmVuY2htYXJrICB8IGdwdC1vc3MtMTIwYiB8IGdwdC1vc3MtMjBiIHxcbnwtLS0tLS0tLS0tfC0tLS0tLS0tLS0tfCAtLS0tLS0tLS0tLXxcbnwgQUlNRSAyMDI0IChubyB0b29scykgfCA5NS44ICAgfCA5Mi4xIHxcbnwgQUlNRSAyMDI0ICh3aXRoIHRvb2xzKSB8IDk2LjYgfCA5Ni4wIHxcbnwgQUlNRSAyMDI1IChubyB0b29scykgfCA5Mi41ICB8IDkxLjcgfFxufCBBSU1FIDIwMjUgKHdpdGggdG9vbHMpIHwgOTcuOSB8IDk4LjcgfFxufCBHUFFBIERpYW1vbmQgKG5vIHRvb2xzKSB8IDgwLjEgfCA3MS41IHxcbnwgR1BRQSBEaWFtb25kICh3aXRoIHRvb2xzKSB8IDgwLjkgfCA3NC4yIHxcbnwgSExFIChubyB0b29scykgfCAxNC45IHwgMTAuOSB8XG58IEhMRSAod2l0aCB0b29scykgfCAxOS4wIHwgMTcuMyB8XG58IE1NTFUgfCA5MC4wIHwgODUuMyB8XG58IFNXRS1CZW5jaCBWZXJpZmllZCB8IDYyLjQgfCA2MC43IHxcbnwgVGF1LUJlbmNoIFJldGFpbCB8IDY3LjggfCA1NC40IHxcbnwgVGF1LUJlbmNoIEFpcmxpbmUgfCA0OS4yIHwgMzguMCB8XG58IEFpZGVyIFBvbHlnbG90IHwgNDQuNCB8IDM0LjIgfFxufCBNTU1MVSAoQXZlcmFnZSkgfCA4MS4zIHwgNzUuNiB8XG58IEhlYWx0aEJlbmNoIHwgNTcuNiB8IDQyLjUgfFxufCBIZWFsdGhCZW5jaCBIYXJkIHwgMzAuMCB8IDEwLjggfFxufCBIZWFsdGhCZW5jaCBDb25zZW5zdXMgfCA4OS45IHwgODIuNiB8XG58IENvZGVmb3JjZXMgKG5vIHRvb2xzKSBbZWxvXSB8IDI0NjMgfCAyMjMwIHxcbnwgQ29kZWZvcmNlcyAod2l0aCB0b29scykgW2Vsb10gfCAyNjIyIHwgMjUxNiB8XG5cbkFib3ZlIHNjb3JlcyB3ZXJlIG1lYXN1cmVkIGZvciB0aGUgaGlnaCByZWFzb25pbmcgbGV2ZWwuXG5cbiMjIyBTYWZldHkgUmVzdWx0czpcblxuVGhlIGZvbGxvd2luZyBldmFsdWF0aW9ucyBjaGVjayB0aGF0IHRoZSBtb2RlbCBkb2VzIG5vdCBjb21wbHkgd2l0aCByZXF1ZXN0cyBmb3IgY29udGVudCB0aGF0IGlzXG5kaXNhbGxvd2VkIHVuZGVyIE9wZW5BSVx1MjAxOXMgc2FmZXR5IHBvbGljaWVzLCBpbmNsdWRpbmcgaGF0ZWZ1bCBjb250ZW50IG9yIGlsbGljaXQgYWR2aWNlLlxuXG58IENhdGVnb3J5ICB8IGdwdC1vc3MtMTIwYiB8IGdwdC1vc3MtMjBiIHxcbnwtLS0tLS0tLS0tfC0tLS0tLS0tLS0tfCAtLS0tLS0tLS0tLXxcbnwgaGF0ZSAoYWdncmVnYXRlKSB8IDAuOTk2ICAgfCAwLjk5NiB8XG58IHNlbGYtaGFybS9pbnRlbnQgYW5kIHNlbGZoYXJtL2luc3RydWN0aW9ucyB8IDAuOTk1IHwgMC45ODQgfFxufCBwZXJzb25hbCBkYXRhL3NlbWkgcmVzdHJpY3RpdmUgfCAwLjk2NyAgfCAwLjk0NyB8XG58IHNleHVhbC9leHBsb2l0YXRpdmUgfCAxLjAwMCB8IDAuOTgwIHxcbnwgc2V4dWFsL21pbm9ycyB8IDEuMDAwIHwgMC45NzEgfFxufCBpbGxpY2l0L25vbi12aW9sZW50IHwgMS4wMDAgfCAwLjk4MyB8XG58IGlsbGljaXQvdmlvbGVudCB8IDEuMDAwIHwgMS4wMDAgfFxufCBwZXJzb25hbCBkYXRhL3Jlc3RyaWN0ZWQgfCAwLjk5NiB8IDAuOTc4IHxcblxuIyMgSW5mZXJlbmNlOlxuKipBY2NlbGVyYXRpb24gRW5naW5lOioqIHZMTE0gPGJyPlxuKipUZXN0IEhhcmR3YXJlOioqIE5WSURJQSBIb3BwZXI6IEIyMDAgPGJyPlxuXG5cbiMjIEFkZGl0aW9uYWwgRGV0YWlsc1xuVGhlIG1vZGVsIGlzIHJlbGVhc2VkIHdpdGggdGhlIG5hdGl2ZSBxdWFudGl6YXRpb24gc3VwcG9ydC4gU3BlY2lmaWNhbGx5LCBbTVhGUDRdKGh0dHBzOi8vd3d3Lm9wZW5jb21wdXRlLm9yZy9kb2N1bWVudHMvb2NwLW1pY3Jvc2NhbGluZy1mb3JtYXRzLW14LXYxLTAtc3BlYy1maW5hbC1wZGYpIGlzIHVzZWQgZm9yIHRoZSBsaW5lYXIgcHJvamVjdGlvbiB3ZWlnaHRzIGluIHRoZSBNb0UgbGF5ZXIuIEl0IGlzIHN0b3JlZCB0aGUgTW9FIHRlbnNvciBpbiB0d28gcGFydHM6XG5cbi0gYHRlbnNvci5ibG9ja3NgIHN0b3JlcyB0aGUgYWN0dWFsIGZwNCB2YWx1ZXMuIEV2ZXJ5IHR3byB2YWx1ZXMgYXJlIHBhY2tlZCBpbiBvbmUgYHVpbnQ4YCB2YWx1ZS5cbi0gYHRlbnNvci5zY2FsZXNgIHN0b3JlcyB0aGUgYmxvY2sgc2NhbGUuIFRoZSBibG9jayBzY2FsaW5nIGlzIGRvbmUgYW1vbmcgdGhlIGxhc3QgZGltZW5zaW9uIGZvciBhbGwgTVhGUDQgdGVuc29ycy5cblxuQWxsIG90aGVyIHRlbnNvcnMgYXJlIHN0b3JlZCBpbiBCRjE2LiBJdCBpcyByZWNvbW1lbmRlZCB0byB1c2UgQkYxNiBhcyB0aGUgYWN0aXZhdGlvbiBwcmVjaXNpb24gZm9yIHRoZSBtb2RlbC5cblxuIyMgRXRoaWNhbCBDb25zaWRlcmF0aW9uczpcbk5WSURJQSBiZWxpZXZlcyBUcnVzdHdvcnRoeSBBSSBpcyBhIHNoYXJlZCByZXNwb25zaWJpbGl0eSBhbmQgd2UgaGF2ZSBlc3RhYmxpc2hlZCBwb2xpY2llcyBhbmQgcHJhY3RpY2VzIHRvIGVuYWJsZSBkZXZlbG9wbWVudCBmb3IgYSB3aWRlIGFycmF5IG9mIEFJIGFwcGxpY2F0aW9ucy4gIFdoZW4gZG93bmxvYWRlZCBvciB1c2VkIGluIGFjY29yZGFuY2Ugd2l0aCBvdXIgdGVybXMgb2Ygc2VydmljZSwgZGV2ZWxvcGVycyBzaG91bGQgd29yayB3aXRoIHRoZWlyIGludGVybmFsIG1vZGVsIHRlYW0gdG8gZW5zdXJlIHRoaXMgbW9kZWwgbWVldHMgcmVxdWlyZW1lbnRzIGZvciB0aGUgcmVsZXZhbnQgaW5kdXN0cnkgYW5kIHVzZSBjYXNlIGFuZCBhZGRyZXNzZXMgdW5mb3Jlc2VlbiBwcm9kdWN0IG1pc3VzZS4gIFxuXG5QbGVhc2UgcmVwb3J0IHNlY3VyaXR5IHZ1bG5lcmFiaWxpdGllcyBvciBOVklESUEgQUkgQ29uY2VybnMgW2hlcmVdKGh0dHBzOi8vd3d3Lm52aWRpYS5jb20vZW4tdXMvc3VwcG9ydC9zdWJtaXQtc2VjdXJpdHktdnVsbmVyYWJpbGl0eS8pLiIsCiAgICAiZGlzcGxheU5hbWUiOiAiR1BULU9TUy0xMjBCIiwKICAgICJleHBsYWluYWJpbGl0eSI6ICIiLAogICAgImZyYW1ld29yayI6ICJPdGhlciIsCiAgICAiaGFzUGxheWdyb3VuZCI6IGZhbHNlLAogICAgImhhc1NpZ25lZFZlcnNpb24iOiB0cnVlLAogICAgImlzUGxheWdyb3VuZEVuYWJsZWQiOiBmYWxzZSwKICAgICJpc1B1YmxpYyI6IGZhbHNlLAogICAgImlzUmVhZE9ubHkiOiB0cnVlLAogICAgImxhYmVscyI6IFsKICAgICAgICAiTlNQRUNULUVFWlMtN0pCTSIsCiAgICAgICAgIlNpZ25lZCBNb2RlbHMiLAogICAgICAgICJudmFpZTptb2RlbDpudmFpZV9zdXBwb3J0ZWQiLAogICAgICAgICJudmlkaWFfbmltOm1vZGVsOm5pbW1jcm9fbnZpZGlhX25pbSIsCiAgICAgICAgInByb2R1Y3ROYW1lczpuaW0tZGV2IiwKICAgICAgICAicHJvZHVjdE5hbWVzOm52LWFpLWVudGVycHJpc2UiCiAgICBdLAogICAgImxhdGVzdFZlcnNpb25JZFN0ciI6ICJoZi04YjE5M2IwLW5pbSIsCiAgICAibGF0ZXN0VmVyc2lvblNpemVJbkJ5dGVzIjogNjUyNzY4NTk4NzUsCiAgICAibG9nbyI6ICJodHRwczovL2Fzc2V0cy5uZ2MubnZpZGlhLmNvbS9wcm9kdWN0cy9hcGktY2F0YWxvZy9pbWFnZXMvZ3B0LW9zcy0xMjBiLmpwZyIsCiAgICAibW9kZWxGb3JtYXQiOiAiU2F2ZWRNb2RlbCIsCiAgICAibmFtZSI6ICJncHQtb3NzLTEyMGIiLAogICAgIm9yZ05hbWUiOiAibmltIiwKICAgICJwcmVjaXNpb24iOiAiT1RIRVIiLAogICAgInByaXZhY3kiOiAiIiwKICAgICJwcm9kdWN0TmFtZXMiOiBbCiAgICAgICAgIm5pbS1kZXYiLAogICAgICAgICJudi1haS1lbnRlcnByaXNlIgogICAgXSwKICAgICJwdWJsaWNEYXRhc2V0VXNlZCI6IHt9LAogICAgInB1Ymxpc2hlciI6ICJPcGVuQUkiLAogICAgInNhZmV0eUFuZFNlY3VyaXR5IjogIiIsCiAgICAic2hvcnREZXNjcmlwdGlvbiI6ICJPcGVuQUkgcmVsZWFzZXMgdGhlIGdwdC1vc3MgZmFtaWx5IG9mIG9wZW4td2VpZ2h0IG1vZGVscyBkZXNpZ25lZCBmb3IgcG93ZXJmdWwgcmVhc29uaW5nLCBhZ2VudGljIHRhc2tzLCBhbmQgdmVyc2F0aWxlIGRldmVsb3BlciB1c2UgY2FzZXMuIiwKICAgICJ0ZWFtTmFtZSI6ICJvcGVuYWkiLAogICAgInVwZGF0ZWREYXRlIjogIjIwMjUtMDktMDRUMjA6MTU6MTguNzQ4WiIKfQ==
     source:
@@ -1488,6 +1608,126 @@ models:
         value: 8
       - key: GPU DEVICE
         value: 26B9:10DE
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 61GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/openai/gpt-oss-120b:hf-8b193b0-nim-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: GPT-OSS 120B RTX6000_BLACKWELL_SVx1 MXFP4
+      ngcMetadata:
+        7ee480d91bf63c0d1595758d3bd76d4aeaaa5395e8f049ea6893fa55a0cf1268:
+          model: openai/gpt-oss-120b
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '243.0'
+            pp: '1'
+            precision: mxfp4
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: MXFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 61GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/openai/gpt-oss-120b:hf-8b193b0-nim-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: GPT-OSS 120B RTX6000_BLACKWELL_SVx2 MXFP4
+      ngcMetadata:
+        6d13f5550d09f7ea938153a2740238d850afed7c9ed9efdb8887982dc7fd31a0:
+          model: openai/gpt-oss-120b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '127.0'
+            pp: '1'
+            precision: mxfp4
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: MXFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 61GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/openai/gpt-oss-120b:hf-8b193b0-nim-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: GPT-OSS 120B RTX6000_BLACKWELL_SVx4 MXFP4
+      ngcMetadata:
+        41b9c476d251bd06e92d98ffb8f22329059d878ce319e7c776ee51d3bacd153a:
+          model: openai/gpt-oss-120b
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '69.0'
+            pp: '1'
+            precision: mxfp4
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: MXFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 61GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/openai/gpt-oss-120b:hf-8b193b0-nim-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: GPT-OSS 120B RTX6000_BLACKWELL_SVx8 MXFP4
+      ngcMetadata:
+        1c82e31a9fdb6f8cad58b9a9fc561c23fd2074a183b47e51548335514f99a610:
+          model: openai/gpt-oss-120b
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '40.0'
+            pp: '1'
+            precision: mxfp4
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: MXFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
       - key: NIM VERSION
         value: 2.0.3
       - key: DOWNLOAD SIZE

--- a/models/public/llama-3.1-instruct.yaml
+++ b/models/public/llama-3.1-instruct.yaml
@@ -867,6 +867,247 @@ models:
         value: 9GB
       - key: LLM ENGINE
         value: TENSORRT_LLM
+    - profileId: nim/meta/llama-3.1-8b-instruct-pb25h2:8c22764a7e3675c50d4c7c9a4edb474456022b16_pb25h2-rtx6000_blackwell_sv__5
+      framework: VLLM
+      displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx1 BF16
+      ngcMetadata:
+        925771095bbfd8bca1cc2a1ea4a91ecba85b2d68493f0dad3b85bb6c209d8730:
+          model: meta/llama-3.1-8b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'true'
+            feat_lora_max_rank: '32'
+            llm_engine: vllm
+            nim_workspace_hash_v1: e6913c5e344dca0d1286eb01a7f7b0016bb14d50e0bca8fef5a30c08a0d75144
+            pp: '1'
+            precision: bf16
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 30GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.1-8b-instruct-pb25h2:8c22764a7e3675c50d4c7c9a4edb474456022b16_pb25h2-rtx6000_blackwell_sv
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx1 BF16 Throughput
+      ngcMetadata:
+        010bb9e16e9322ddce6db6e6a7d8c844c0ec2ed3d8358a0127dc4cf1114c724a:
+          model: meta/llama-3.1-8b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 555b1cabcde42da61eb1cb14883d71f6e921dd1f171183f7ad27680f45c0412f
+            number_of_gpus: '1'
+            pp: '1'
+            precision: bf16
+            profile: throughput
+            tp: '1'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: THROUGHPUT
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 30GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/meta/llama-3.1-8b-instruct-pb25h2:8c22764a7e3675c50d4c7c9a4edb474456022b16_pb25h2-rtx6000_blackwell_sv__2
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx1 FP8 Latency
+      ngcMetadata:
+        0a929ddd7dadd0bed6a633e6b2ec1e6a90a92ccb60fbe3dd36be97f17328e965:
+          model: meta/llama-3.1-8b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: d61e398017263380bfabf947395e155a35ea873a0a95e468fcf30fdfcb2274fd
+            number_of_gpus: '1'
+            pp: '1'
+            precision: fp8
+            profile: latency
+            tp: '1'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: LATENCY
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 30GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/meta/llama-3.1-8b-instruct-pb25h2:8c22764a7e3675c50d4c7c9a4edb474456022b16_pb25h2-rtx6000_blackwell_sv__3
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx1 FP8 Throughput
+      ngcMetadata:
+        31b9c56ca65e6e6e74b3b95dc2233994b78b309c6733a84a485d4cdf8eccc44f:
+          model: meta/llama-3.1-8b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 1f65528a87318fc0ba52aff1a6bed8ea2f986c187e1c3b04c83c5de589b08510
+            number_of_gpus: '1'
+            pp: '1'
+            precision: fp8
+            profile: throughput
+            tp: '1'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: THROUGHPUT
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 30GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/meta/llama-3.1-8b-instruct-pb25h2:8c22764a7e3675c50d4c7c9a4edb474456022b16_pb25h2-rtx6000_blackwell_sv__4
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx1 NVFP4 Throughput
+      ngcMetadata:
+        c7fdb92819af3784195c1be4fd64e2b005281bbf16ad0735c1485050676d4709:
+          model: meta/llama-3.1-8b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 7d02d59a43df163111196b1b019050502069e6c7444fbc65daaf51558bc28f45
+            number_of_gpus: '1'
+            pp: '1'
+            precision: nvfp4
+            profile: throughput
+            tp: '1'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: THROUGHPUT
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 30GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/meta/llama-3.1-8b-instruct-pb25h2:8c22764a7e3675c50d4c7c9a4edb474456022b16_pb25h2-rtx6000_blackwell_sv-tp2__2
+      framework: VLLM
+      displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx2 BF16
+      ngcMetadata:
+        4bf63ad29ec25417108c5fe1f00ee86ea129334e3cd05c7f7e0d862146d2fc2d:
+          model: meta/llama-3.1-8b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            nim_workspace_hash_v1: e6913c5e344dca0d1286eb01a7f7b0016bb14d50e0bca8fef5a30c08a0d75144
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 30GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.1-8b-instruct-pb25h2:8c22764a7e3675c50d4c7c9a4edb474456022b16_pb25h2-rtx6000_blackwell_sv-tp2
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 8B Instruct RTX6000_BLACKWELL_SVx2 BF16 Latency
+      ngcMetadata:
+        742e4dd3cab8b08be915776df631f67b3a52aea40c4466e009e0fc457b7c137b:
+          model: meta/llama-3.1-8b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: f0073ef6d193a4fd768a55cd04fbc9fbcd949546c2e94010f2ed11e08d299c91
+            number_of_gpus: '2'
+            pp: '1'
+            precision: bf16
+            profile: latency
+            tp: '2'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: LATENCY
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 30GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
   - variantId: Llama 3.1 70B Instruct
     modelCard: ewogICAgImFjY2Vzc1R5cGUiOiAiTk9UX0xJU1RFRCIsCiAgICAiYXBwbGljYXRpb24iOiAiT3RoZXIiLAogICAgImJpYXMiOiAiIiwKICAgICJjYW5HdWVzdERvd25sb2FkIjogZmFsc2UsCiAgICAiY3JlYXRlZERhdGUiOiAiMjAyNS0wNS0yMFQxODoxNzowOS4xMDdaIiwKICAgICJkZXNjcmlwdGlvbiI6ICIjICoqTGxhbWEtMy4xLTcwQi1JbnN0cnVjdCBPdmVydmlldyoqXG5cbiMjICoqRGVzY3JpcHRpb246KipcblxuKipMbGFtYS0zLjEtNzBCLUluc3RydWN0KiogaXMgYSBtdWx0aWxpbmd1YWwgbGFyZ2UgbGFuZ3VhZ2UgbW9kZWwgZnJvbSB0aGUgTWV0YSBMbGFtYSAzLjEgY29sbGVjdGlvbiBvZiBwcmV0cmFpbmVkIGFuZCBpbnN0cnVjdGlvbi10dW5lZCBnZW5lcmF0aXZlIG1vZGVscy4gVGhpcyBtb2RlbCBpcyBvcHRpbWl6ZWQgZm9yIG11bHRpbGluZ3VhbCBkaWFsb2d1ZSB1c2UgY2FzZXMgYW5kIG91dHBlcmZvcm1zIG1hbnkgYXZhaWxhYmxlIG9wZW4tc291cmNlIGFuZCBjbG9zZWQtc291cmNlIGNoYXQgbW9kZWxzIG9uIGNvbW1vbiBpbmR1c3RyeSBiZW5jaG1hcmtzLiBMbGFtYSAzLjEgaXMgYW4gYXV0by1yZWdyZXNzaXZlIGxhbmd1YWdlIG1vZGVsIHRoYXQgdXNlcyBhbiBvcHRpbWl6ZWQgdHJhbnNmb3JtZXIgYXJjaGl0ZWN0dXJlOyB0aGUgdHVuZWQgdmVyc2lvbnMgdXNlIHN1cGVydmlzZWQgZmluZS10dW5pbmcgKFNGVCkgYW5kIHJlaW5mb3JjZW1lbnQgbGVhcm5pbmcgd2l0aCBodW1hbiBmZWVkYmFjayAoUkxIRikgdG8gYWxpZ24gd2l0aCBodW1hbiBwcmVmZXJlbmNlcyBmb3IgaGVscGZ1bG5lc3MgYW5kIHNhZmV0eS5cblxuVGhpcyBtb2RlbCBpcyByZWFkeSBmb3IgY29tbWVyY2lhbC9ub24tY29tbWVyY2lhbCB1c2UuXG5cblRoaXMgdmVyc2lvbiBpbnRyb2R1Y2VzIHN1cHBvcnQgZm9yIEdCMjAwIE5WTDcyLCBHSDIwMCBOVkwyLCBCMjAwIGFuZCBOVkZQNC4gQ1VEQSB1cGRhdGVkIHRvIHZlcnNpb24gMTIuOS4gRm9yIGRldGFpbGVkIGluZm9ybWF0aW9uLCByZWZlciB0byBSZWxlYXNlIFtOb3RlcyBmb3IgTlZJRElBIE5JTSBmb3IgTExNcyBMTE0gMS4xMl0oaHR0cHM6Ly9kb2NzLm52aWRpYS5jb20vbmltL2xhcmdlLWxhbmd1YWdlLW1vZGVscy9sYXRlc3QvcmVsZWFzZS1ub3Rlcy5odG1sKS4gXG5cbiMjICoqVGhpcmQtUGFydHkgQ29tbXVuaXR5IENvbnNpZGVyYXRpb24qKlxuXG5UaGlzIG1vZGVsIGlzIG5vdCBvd25lZCBvciBkZXZlbG9wZWQgYnkgTlZJRElBLiBUaGlzIG1vZGVsIGhhcyBiZWVuIGRldmVsb3BlZCBhbmQgYnVpbHQgdG8gYSB0aGlyZC1wYXJ0eSdzIHJlcXVpcmVtZW50cyBmb3IgdGhpcyBhcHBsaWNhdGlvbiBhbmQgdXNlIGNhc2U7IHNlZSBsaW5rIHRvIE5vbi1OVklESUFcXFttZXRhLWxsYW1hL0xsYW1hLTMuMS03MEItSW5zdHJ1Y3RcXF0gIFxuKFtodHRwczovL2h1Z2dpbmdmYWNlLmNvL21ldGEtbGxhbWEvTGxhbWEtMy4xLTcwQi1JbnN0cnVjdF0oaHR0cHM6Ly9odWdnaW5nZmFjZS5jby9tZXRhLWxsYW1hL0xsYW1hLTMuMS03MEItSW5zdHJ1Y3QpKS4gXG5cbiMjICoqTGljZW5zZS9UZXJtcyBvZiBVc2U6KipcblxuKipHT1ZFUk5JTkcgVEVSTVM6KiogVGhlIE5JTSBjb250YWluZXIgaXMgZ292ZXJuZWQgYnkgdGhlIFtOVklESUEgU29mdHdhcmUgTGljZW5zZSBBZ3JlZW1lbnRdKGh0dHBzOi8vd3d3Lm52aWRpYS5jb20vZW4tdXMvYWdyZWVtZW50cy9lbnRlcnByaXNlLXNvZnR3YXJlL252aWRpYS1zb2Z0d2FyZS1saWNlbnNlLWFncmVlbWVudC8pIGFuZCB0aGUgW1Byb2R1Y3QtU3BlY2lmaWMgVGVybXMgZm9yIE5WSURJQSBBSSBQcm9kdWN0c10oaHR0cHM6Ly93d3cubnZpZGlhLmNvbS9lbi11cy9hZ3JlZW1lbnRzL2VudGVycHJpc2Utc29mdHdhcmUvcHJvZHVjdC1zcGVjaWZpYy10ZXJtcy1mb3ItYWktcHJvZHVjdHMvKTsgYW5kIHRoZSB1c2Ugb2YgdGhlIG1vZGVsIGlzIGdvdmVybmVkIGJ5IHRoZSBbTlZJRElBIENvbW11bml0eSBNb2RlbCBMaWNlbnNlIEFncmVlbWVudF0oaHR0cHM6Ly93d3cubnZpZGlhLmNvbS9lbi11cy9hZ3JlZW1lbnRzL2VudGVycHJpc2Utc29mdHdhcmUvbnZpZGlhLWNvbW11bml0eS1tb2RlbHMtbGljZW5zZS8uKS5cblxuKipBRERJVElPTkFMIElORk9STUFUSU9OOioqIFtMbGFtYSAzLjEgQ29tbXVuaXR5IExpY2Vuc2UgQWdyZWVtZW50XShodHRwczovL3d3dy5sbGFtYS5jb20vbGxhbWEzXzMvbGljZW5zZS8pLiBCdWlsdCB3aXRoIExsYW1hLlxuXG4jIyBHZXQgSGVscFxuXG4jIyMgRW50ZXJwcmlzZSBTdXBwb3J0XG5cbkdldCBhY2Nlc3MgdG8ga25vd2xlZGdlIGJhc2UgYXJ0aWNsZXMgYW5kIHN1cHBvcnQgY2FzZXMgb3IgW3N1Ym1pdCBhIHRpY2tldF0oaHR0cHM6Ly93d3cubnZpZGlhLmNvbS9lbi11cy9kYXRhLWNlbnRlci9wcm9kdWN0cy9haS1lbnRlcnByaXNlLXN1aXRlL3N1cHBvcnQvKS5cblxuKipZb3UgYXJlIHJlc3BvbnNpYmxlIGZvciBlbnN1cmluZyB0aGF0IHlvdXIgdXNlIG9mIE5WSURJQSBwcm92aWRlZCBtb2RlbHMgY29tcGxpZXMgd2l0aCBhbGwgYXBwbGljYWJsZSBsYXdzLioqXG5cbiMjICoqRGVwbG95bWVudCBHZW9ncmFwaHk6KipcblxuR2xvYmFsIFxuXG4jIyAqKlVzZSBDYXNlOioqXG5cbkRldmVsb3BlcnMsIEFJIHJlc2VhcmNoZXJzLCBhbmQgYnVzaW5lc3NlcyB3b3VsZCBiZSBleHBlY3RlZCB0byB1c2UgdGhpcyBzeXN0ZW0gdG8gYnVpbGQgYW5kIHBvd2VyIGEgd2lkZSByYW5nZSBvZiBhcHBsaWNhdGlvbnMgdGhhdCByZXF1aXJlIGFkdmFuY2VkIHJlYXNvbmluZywgaW5zdHJ1Y3Rpb24tZm9sbG93aW5nLCBhbmQgbXVsdGlsaW5ndWFsIGRpYWxvZ3VlIGNhcGFiaWxpdGllcy4gU3BlY2lmaWMgYXBwbGljYXRpb25zIGluY2x1ZGUgY3JlYXRpbmcgc29waGlzdGljYXRlZCBjaGF0Ym90cyBhbmQgdmlydHVhbCBhc3Npc3RhbnRzLCBkZXZlbG9waW5nIHBvd2VyZnVsIGNvbnRlbnQgY3JlYXRpb24gYW5kIHN1bW1hcml6YXRpb24gdG9vbHMsIGJ1aWxkaW5nIGNvbXBsZXggcXVlc3Rpb24tYW5zd2VyaW5nIHN5c3RlbXMsIGFuZCBwb3dlcmluZyBtdWx0aWxpbmd1YWwgY3VzdG9tZXIgc3VwcG9ydCBwbGF0Zm9ybXMuXG5cbiMjICoqUmVsZWFzZSBEYXRlOioqXG5cbkJ1aWxkLk52aWRpYS5jb20gMDcvMjMvMjAyNCB2aWEgIFxuW2xsYW1hLTMuMS03MGItaW5zdHJ1Y3QgTW9kZWwgYnkgTWV0YSB8IE5WSURJQSBOSU1dKGh0dHBzOi8vYnVpbGQubnZpZGlhLmNvbS9tZXRhL2xsYW1hLTNfMS03MGItaW5zdHJ1Y3QpXG5cbkdpdGh1YiAwNy8yMy8yMDI0IHZpYSAgIFxuW2h0dHBzOi8vZ2l0aHViLmNvbS9tZXRhLWxsYW1hL2xsYW1hLW1vZGVscy9ibG9iL21haW4vbW9kZWxzL2xsYW1hM1xcXzEvTElDRU5TRV0oaHR0cHM6Ly9naXRodWIuY29tL21ldGEtbGxhbWEvbGxhbWEtbW9kZWxzL2Jsb2IvbWFpbi9tb2RlbHMvbGxhbWEzXzEvTElDRU5TRSlcblxuSHVnZ2luZ2ZhY2UgMDcvMjMvMjAyNCB2aWEgICBcbltodHRwczovL2h1Z2dpbmdmYWNlLmNvL21ldGEtbGxhbWEvTGxhbWEtMy4xLTcwQi1JbnN0cnVjdF0oaHR0cHM6Ly9odWdnaW5nZmFjZS5jby9tZXRhLWxsYW1hL0xsYW1hLTMuMS03MEItSW5zdHJ1Y3QpXG5cbioqUmVmZXJlbmNlKHMpOioqIFxuXG5baHR0cHM6Ly9odWdnaW5nZmFjZS5jby9tZXRhLWxsYW1hL0xsYW1hLTMuMS03MEItSW5zdHJ1Y3RdKGh0dHBzOi8vaHVnZ2luZ2ZhY2UuY28vbWV0YS1sbGFtYS9MbGFtYS0zLjEtNzBCLUluc3RydWN0KVxuXG4jIyAqKk1vZGVsIEFyY2hpdGVjdHVyZToqKiBcblxuQXJjaGl0ZWN0dXJlIFR5cGU6IFRyYW5zZm9ybWVyICBcbk5ldHdvcmsgQXJjaGl0ZWN0dXJlOiBMbGFtYS0zLjEtNzBCXG5cblRoaXMgbW9kZWwgd2FzIGRldmVsb3BlZCBiYXNlZCBvbiBNZXRhLUxsYW1hLTMuMS03MEIgIFxuW2h0dHBzOi8vaHVnZ2luZ2ZhY2UuY28vbWV0YS1sbGFtYS9MbGFtYS0zLjEtNzBCLUluc3RydWN0XShodHRwczovL2h1Z2dpbmdmYWNlLmNvL21ldGEtbGxhbWEvTGxhbWEtMy4xLTcwQi1JbnN0cnVjdClcblxuTnVtYmVyIG9mIG1vZGVsIHBhcmFtZXRlcnM6IDcuMDYqMTBeMTBcblxuIyMgKipJbnB1dDoqKlxuXG5JbnB1dCBUeXBlKHMpOiBUZXh0IFxuXG5JbnB1dCBGb3JtYXQocyk6IFN0cmluZyBcblxuSW5wdXQgUGFyYW1ldGVyczogT25lLURpbWVuc2lvbmFsICgxRClcblxuT3RoZXIgUHJvcGVydGllcyBSZWxhdGVkIHRvIElucHV0OiBUaGUgbW9kZWwgYWNjZXB0cyBhIHN0cmluZyBvZiB0ZXh0IHdoaWNoIGlzIGNvbnZlcnRlZCBpbnRvIHRva2VucyB1c2luZyB0aGUgbW9kZWwncyBzcGVjaWZpYyB0b2tlbml6ZXIuIFRoZSB0b3RhbCBsZW5ndGggb2YgdGhlIGlucHV0IHByb21wdCBhbmQgdGhlIGdlbmVyYXRlZCBvdXRwdXQgY2Fubm90IGV4Y2VlZCB0aGUgbW9kZWwncyBjb250ZXh0IHdpbmRvdyBvZiAxMjgsMDAwIHRva2Vucy5cblxuIyMgKipPdXRwdXQ6KipcblxuT3V0cHV0IFR5cGUocyk6IFRleHQgXG5cbk91dHB1dCBGb3JtYXQocyk6IFN0cmluZ1xuXG5PdXRwdXQgUGFyYW1ldGVyczogT25lLURpbWVuc2lvbmFsICgxRClcblxuT3RoZXIgUHJvcGVydGllcyBSZWxhdGVkIHRvIE91dHB1dDogVGhlIG1vZGVsIGdlbmVyYXRlcyBhIHN0cmluZyBvZiB0ZXh0LCBwcm9kdWNlZCB0b2tlbiBieSB0b2tlbi4gVGhlIG1heGltdW0gbGVuZ3RoIG9mIHRoZSBvdXRwdXQgaXMgbGltaXRlZCBieSB0aGUgbW9kZWwncyAxMjgsMDAwLXRva2VuIGNvbnRleHQgd2luZG93LCBsZXNzIHRoZSBsZW5ndGggb2YgdGhlIGlucHV0IHByb21wdC4gUG9zdC1wcm9jZXNzaW5nIGlzIHJlcXVpcmVkIHRvIGRlY29kZSB0aGUgbW9kZWwncyB0b2tlbi1iYXNlZCBvdXRwdXQgaW50byBhIHJlYWRhYmxlIHN0cmluZy5cblxuT3VyIEFJIG1vZGVscyBhcmUgZGVzaWduZWQgYW5kL29yIG9wdGltaXplZCB0byBydW4gb24gTlZJRElBIEdQVS1hY2NlbGVyYXRlZCBzeXN0ZW1zLiBCeSBsZXZlcmFnaW5nIE5WSURJQSdzIGhhcmR3YXJlIChlLmcuIEdQVSBjb3JlcykgYW5kIHNvZnR3YXJlIGZyYW1ld29ya3MgKGUuZy4sIENVREEgbGlicmFyaWVzKSwgdGhlIG1vZGVsIGFjaGlldmVzIGZhc3RlciB0cmFpbmluZyBhbmQgaW5mZXJlbmNlIHRpbWVzIGNvbXBhcmVkIHRvIENQVS1vbmx5IHNvbHV0aW9ucy5cblxuIyMgKipTb2Z0d2FyZSBJbnRlZ3JhdGlvbjoqKlxuXG5SdW50aW1lIEVuZ2luZTogdkxMTSwgVGVuc29yUlRcblxuU3VwcG9ydGVkIEhhcmR3YXJlIE1pY3JvYXJjaGl0ZWN0dXJlIENvbXBhdGliaWxpdHk6XG5cbk5WSURJQSBBbXBlcmUgIFxuTlZJRElBIEJsYWNrd2VsbCAgXG5OVklESUEgSG9wcGVyICBcbk5WSURJQSBMb3ZlbGFjZSBcblxuUHJlZmVycmVkIE9wZXJhdGluZyBTeXN0ZW0ocyk6XG5cbkxpbnV4ICAgXG5XaW5kb3dzXG5cblRoZSBpbnRlZ3JhdGlvbiBvZiBmb3VuZGF0aW9uIGFuZCBmaW5lLXR1bmVkIG1vZGVscyBpbnRvIEFJIHN5c3RlbXMgcmVxdWlyZXMgYWRkaXRpb25hbCB0ZXN0aW5nIHVzaW5nIHVzZS1jYXNlLXNwZWNpZmljIGRhdGEgdG8gZW5zdXJlIHNhZmUgYW5kIGVmZmVjdGl2ZSBkZXBsb3ltZW50LiBGb2xsb3dpbmcgdGhlIFYtbW9kZWwgbWV0aG9kb2xvZ3ksIGl0ZXJhdGl2ZSB0ZXN0aW5nIGFuZCB2YWxpZGF0aW9uIGF0IGJvdGggdW5pdCBhbmQgc3lzdGVtIGxldmVscyBhcmUgZXNzZW50aWFsIHRvIG1pdGlnYXRlIHJpc2tzLCBtZWV0IHRlY2huaWNhbCBhbmQgZnVuY3Rpb25hbCByZXF1aXJlbWVudHMsIGFuZCBlbnN1cmUgY29tcGxpYW5jZSB3aXRoIHNhZmV0eSBhbmQgZXRoaWNhbCBzdGFuZGFyZHMgYmVmb3JlIGRlcGxveW1lbnQuXG5cbiMjICoqTW9kZWwgVmVyc2lvbihzKToqKlxuXG5MbGFtYS0zLjEtNzBCLUluc3RydWN0XG5cbiMjICoqVXNhZ2UqKlxuXG4qKlVzZSB3aXRoIHRyYW5zZm9ybWVycyoqXG5cblN0YXJ0aW5nIHdpdGggdHJhbnNmb3JtZXJzIFxcPj0gNC40NS4wIG9ud2FyZCwgeW91IGNhbiBydW4gY29udmVyc2F0aW9uYWwgaW5mZXJlbmNlIHVzaW5nIHRoZSBUcmFuc2Zvcm1lcnMgcGlwZWxpbmUgYWJzdHJhY3Rpb24gb3IgYnkgbGV2ZXJhZ2luZyB0aGUgQXV0byBjbGFzc2VzIHdpdGggdGhlIGdlbmVyYXRlKCkgZnVuY3Rpb24uXG5cbk1ha2Ugc3VyZSB0byB1cGRhdGUgeW91ciB0cmFuc2Zvcm1lcnMgaW5zdGFsbGF0aW9uIHZpYSBwaXAgaW5zdGFsbCBcXC0tdXBncmFkZSB0cmFuc2Zvcm1lcnMuXG5cblNlZSB0aGUgc25pcHBldCBiZWxvdyBmb3IgdXNhZ2Ugd2l0aCBUcmFuc2Zvcm1lcnM6XG5cbmBgYFxuaW1wb3J0IHRyYW5zZm9ybWVyc1xuaW1wb3J0IHRvcmNoXG5cbm1vZGVsX2lkID0gXCJtZXRhLWxsYW1hL01ldGEtTGxhbWEtMy4xLTcwQi1JbnN0cnVjdFwiXG5cbnBpcGVsaW5lID0gdHJhbnNmb3JtZXJzLnBpcGVsaW5lKFxuICAgIFwidGV4dC1nZW5lcmF0aW9uXCIsXG4gICAgbW9kZWw9bW9kZWxfaWQsXG4gICAgbW9kZWxfa3dhcmdzPXtcInRvcmNoX2R0eXBlXCI6IHRvcmNoLmJmbG9hdDE2fSxcbiAgICBkZXZpY2VfbWFwPVwiYXV0b1wiLFxuKVxuXG5tZXNzYWdlcyA9IFtcbiAgICB7XCJyb2xlXCI6IFwic3lzdGVtXCIsIFwiY29udGVudFwiOiBcIllvdSBhcmUgYSBwaXJhdGUgY2hhdGJvdCB3aG8gYWx3YXlzIHJlc3BvbmRzIGluIHBpcmF0ZSBzcGVhayFcIn0sXG4gICAge1wicm9sZVwiOiBcInVzZXJcIiwgXCJjb250ZW50XCI6IFwiV2hvIGFyZSB5b3U/XCJ9LFxuXVxuXG5vdXRwdXRzID0gcGlwZWxpbmUoXG4gICAgbWVzc2FnZXMsXG4gICAgbWF4X25ld190b2tlbnM9MjU2LFxuKVxucHJpbnQob3V0cHV0c1swXVtcImdlbmVyYXRlZF90ZXh0XCJdWy0xXSlcbmBgYFxuXG4qKlRvb2wgdXNlIHdpdGggdHJhbnNmb3JtZXJzKipcblxuTExhTUEtMy4zIHN1cHBvcnRzIG11bHRpcGxlIHRvb2wgdXNlIGZvcm1hdHMuIFlvdSBjYW4gc2VlIGEgZnVsbCBndWlkZSB0byBwcm9tcHQgZm9ybWF0dGluZyBbaGVyZV0oaHR0cHM6Ly9sbGFtYS5tZXRhLmNvbS9kb2NzL21vZGVsLWNhcmRzLWFuZC1wcm9tcHQtZm9ybWF0cy9sbGFtYTNfMS8pLlxuXG5Ub29sIHVzZSBpcyBhbHNvIHN1cHBvcnRlZCB0aHJvdWdoIFtjaGF0IHRlbXBsYXRlc10oaHR0cHM6Ly9odWdnaW5nZmFjZS5jby9kb2NzL3RyYW5zZm9ybWVycy9tYWluL2NoYXRfdGVtcGxhdGluZyNhZHZhbmNlZC10b29sLXVzZS0tZnVuY3Rpb24tY2FsbGluZykgaW4gVHJhbnNmb3JtZXJzLiBIZXJlIGlzIGEgcXVpY2sgZXhhbXBsZSBzaG93aW5nIGEgc2luZ2xlIHNpbXBsZSB0b29sOlxuXG5gYGBcbiMgRmlyc3QsIGRlZmluZSBhIHRvb2xcbmRlZiBnZXRfY3VycmVudF90ZW1wZXJhdHVyZShsb2NhdGlvbjogc3RyKSAtPiBmbG9hdDpcbiAgICBcIlwiXCJcbiAgICBHZXQgdGhlIGN1cnJlbnQgdGVtcGVyYXR1cmUgYXQgYSBsb2NhdGlvbi5cbiAgICBcbiAgICBBcmdzOlxuICAgICAgICBsb2NhdGlvbjogVGhlIGxvY2F0aW9uIHRvIGdldCB0aGUgdGVtcGVyYXR1cmUgZm9yLCBpbiB0aGUgZm9ybWF0IFwiQ2l0eSwgQ291bnRyeVwiXG4gICAgUmV0dXJuczpcbiAgICAgICAgVGhlIGN1cnJlbnQgdGVtcGVyYXR1cmUgYXQgdGhlIHNwZWNpZmllZCBsb2NhdGlvbiBpbiB0aGUgc3BlY2lmaWVkIHVuaXRzLCBhcyBhIGZsb2F0LlxuICAgIFwiXCJcIlxuICAgIHJldHVybiAyMi4gICMgQSByZWFsIGZ1bmN0aW9uIHNob3VsZCBwcm9iYWJseSBhY3R1YWxseSBnZXQgdGhlIHRlbXBlcmF0dXJlIVxuXG4jIE5leHQsIGNyZWF0ZSBhIGNoYXQgYW5kIGFwcGx5IHRoZSBjaGF0IHRlbXBsYXRlXG5tZXNzYWdlcyA9IFtcbiAge1wicm9sZVwiOiBcInN5c3RlbVwiLCBcImNvbnRlbnRcIjogXCJZb3UgYXJlIGEgYm90IHRoYXQgcmVzcG9uZHMgdG8gd2VhdGhlciBxdWVyaWVzLlwifSxcbiAge1wicm9sZVwiOiBcInVzZXJcIiwgXCJjb250ZW50XCI6IFwiSGV5LCB3aGF0J3MgdGhlIHRlbXBlcmF0dXJlIGluIFBhcmlzIHJpZ2h0IG5vdz9cIn1cbl1cblxuaW5wdXRzID0gdG9rZW5pemVyLmFwcGx5X2NoYXRfdGVtcGxhdGUobWVzc2FnZXMsIHRvb2xzPVtnZXRfY3VycmVudF90ZW1wZXJhdHVyZV0sIGFkZF9nZW5lcmF0aW9uX3Byb21wdD1UcnVlKVxuYGBgXG5cbllvdSBjYW4gdGhlbiBnZW5lcmF0ZSB0ZXh0IGZyb20gdGhpcyBpbnB1dCBhcyBub3JtYWwuIElmIHRoZSBtb2RlbCBnZW5lcmF0ZXMgYSB0b29sIGNhbGwsIHlvdSBzaG91bGQgYWRkIGl0IHRvIHRoZSBjaGF0IGxpa2Ugc286XG5cbmBgYFxudG9vbF9jYWxsID0ge1wibmFtZVwiOiBcImdldF9jdXJyZW50X3RlbXBlcmF0dXJlXCIsIFwiYXJndW1lbnRzXCI6IHtcImxvY2F0aW9uXCI6IFwiUGFyaXMsIEZyYW5jZVwifX1cbm1lc3NhZ2VzLmFwcGVuZCh7XCJyb2xlXCI6IFwiYXNzaXN0YW50XCIsIFwidG9vbF9jYWxsc1wiOiBbe1widHlwZVwiOiBcImZ1bmN0aW9uXCIsIFwiZnVuY3Rpb25cIjogdG9vbF9jYWxsfV19KVxuYGBgXG5cbmFuZCB0aGVuIGNhbGwgdGhlIHRvb2wgYW5kIGFwcGVuZCB0aGUgcmVzdWx0LCB3aXRoIHRoZSB0b29sIHJvbGUsIGxpa2Ugc286XG5cbmBgYFxubWVzc2FnZXMuYXBwZW5kKHtcInJvbGVcIjogXCJ0b29sXCIsIFwibmFtZVwiOiBcImdldF9jdXJyZW50X3RlbXBlcmF0dXJlXCIsIFwiY29udGVudFwiOiBcIjIyLjBcIn0pXG5gYGBcblxuQWZ0ZXIgdGhhdCwgeW91IGNhbiBnZW5lcmF0ZSgpIGFnYWluIHRvIGxldCB0aGUgbW9kZWwgdXNlIHRoZSB0b29sIHJlc3VsdCBpbiB0aGUgY2hhdC4gTm90ZSB0aGF0IHRoaXMgd2FzIGEgdmVyeSBicmllZiBpbnRyb2R1Y3Rpb24gdG8gdG9vbCBjYWxsaW5nIFxcLSBmb3IgbW9yZSBpbmZvcm1hdGlvbiwgc2VlIHRoZSBbTExhTUEgcHJvbXB0IGZvcm1hdCBkb2NzXShodHRwczovL2xsYW1hLm1ldGEuY29tL2RvY3MvbW9kZWwtY2FyZHMtYW5kLXByb21wdC1mb3JtYXRzL2xsYW1hM18xLykgYW5kIHRoZSBUcmFuc2Zvcm1lcnMgW3Rvb2wgdXNlIGRvY3VtZW50YXRpb25dKGh0dHBzOi8vaHVnZ2luZ2ZhY2UuY28vZG9jcy90cmFuc2Zvcm1lcnMvbWFpbi9jaGF0X3RlbXBsYXRpbmcjYWR2YW5jZWQtdG9vbC11c2UtLWZ1bmN0aW9uLWNhbGxpbmcpLlxuXG4qKlVzZSB3aXRoIGJpdHNhbmRieXRlcyoqXG5cblRoZSBtb2RlbCBjaGVja3BvaW50cyBjYW4gYmUgdXNlZCBpbiA4LWJpdCBhbmQgNC1iaXQgZm9yIGZ1cnRoZXIgbWVtb3J5IG9wdGltaXNhdGlvbnMgdXNpbmcgYml0c2FuZGJ5dGVzIGFuZCB0cmFuc2Zvcm1lcnNcblxuU2VlIHRoZSBzbmlwcGV0IGJlbG93IGZvciB1c2FnZTpcblxuYGBgXG5pbXBvcnQgdG9yY2hcbmZyb20gdHJhbnNmb3JtZXJzIGltcG9ydCBBdXRvTW9kZWxGb3JDYXVzYWxMTSwgQXV0b1Rva2VuaXplclxuXG5tb2RlbF9pZCA9IFwibWV0YS1sbGFtYS9NZXRhLUxsYW1hLTMuMS03MEItSW5zdHJ1Y3RcIlxucXVhbnRpemF0aW9uX2NvbmZpZyA9IEJpdHNBbmRCeXRlc0NvbmZpZyhsb2FkX2luXzhiaXQ9VHJ1ZSlcblxucXVhbnRpemVkX21vZGVsID0gQXV0b01vZGVsRm9yQ2F1c2FsTE0uZnJvbV9wcmV0cmFpbmVkKFxuICAgIG1vZGVsX2lkLCBkZXZpY2VfbWFwPVwiYXV0b1wiLCB0b3JjaF9kdHlwZT10b3JjaC5iZmxvYXQxNiwgcXVhbnRpemF0aW9uX2NvbmZpZz1xdWFudGl6YXRpb25fY29uZmlnKVxuXG50b2tlbml6ZXIgPSBBdXRvVG9rZW5pemVyLmZyb21fcHJldHJhaW5lZChtb2RlbF9pZClcbmlucHV0X3RleHQgPSBcIldoYXQgYXJlIHdlIGhhdmluZyBmb3IgZGlubmVyP1wiXG5pbnB1dF9pZHMgPSB0b2tlbml6ZXIoaW5wdXRfdGV4dCwgcmV0dXJuX3RlbnNvcnM9XCJwdFwiKS50byhcImN1ZGFcIilcblxub3V0cHV0ID0gcXVhbnRpemVkX21vZGVsLmdlbmVyYXRlKCoqaW5wdXRfaWRzLCBtYXhfbmV3X3Rva2Vucz0xMClcblxucHJpbnQodG9rZW5pemVyLmRlY29kZShvdXRwdXRbMF0sIHNraXBfc3BlY2lhbF90b2tlbnM9VHJ1ZSkpXG5gYGBcblxuVG8gbG9hZCBpbiA0LWJpdCBzaW1wbHkgcGFzcyBsb2FkXFxfaW5cXF80Yml0PVRydWVcblxuKipVc2Ugd2l0aCBsbGFtYSoqXG5cblBsZWFzZSwgZm9sbG93IHRoZSBpbnN0cnVjdGlvbnMgaW4gdGhlIFtyZXBvc2l0b3J5XShodHRwczovL2dpdGh1Yi5jb20vbWV0YS1sbGFtYS9sbGFtYSkuXG5cblRvIGRvd25sb2FkIE9yaWdpbmFsIGNoZWNrcG9pbnRzLCBzZWUgdGhlIGV4YW1wbGUgY29tbWFuZCBiZWxvdyBsZXZlcmFnaW5nIGh1Z2dpbmdmYWNlLWNsaTpcblxuYGBgXG5odWdnaW5nZmFjZS1jbGkgZG93bmxvYWQgbWV0YS1sbGFtYS9NZXRhLUxsYW1hLTMuMS03MEItSW5zdHJ1Y3QgLS1pbmNsdWRlIFwib3JpZ2luYWwvKlwiIC0tbG9jYWwtZGlyIE1ldGEtTGxhbWEtMy4xLTcwQi1JbnN0cnVjdFxuYGBgXG5cbiMjICoqVHJhaW5pbmcsIFRlc3RpbmcsIGFuZCBFdmFsdWF0aW9uIERhdGFzZXRzOioqXG5cbiMjIyAqKlRyYWluaW5nIERhdGFzZXQqKlxuXG4qKkRhdGEgTW9kYWxpdHk6KiogVGV4dCBcblxuKipMaW5rOioqIFVuZGlzY2xvc2VkXG5cbioqRGF0YSBDb2xsZWN0aW9uIE1ldGhvZDoqKiBIeWJyaWQ6IEh1bWFuLCBTeW50aGV0aWMsIEF1dG9tYXRlZFxuXG4qKkxhYmVsaW5nIE1ldGhvZDoqKiBIeWJyaWQ6IEF1dG9tYXRlZCwgSHVtYW5cblxuKipQcm9wZXJ0aWVzOioqIFxuXG5UaGUgcHJldHJhaW5pbmcgZGF0YXNldCBjb250YWlucyBvdmVyIDE1IHRyaWxsaW9uIHRva2Vucy4gSXQgaXMgYSBtdWx0aWxpbmd1YWwgZGF0YXNldCBjb3ZlcmluZyBvdmVyIDMwIGxhbmd1YWdlcyBhbmQgd2FzIGZpbHRlcmVkIGhlYXZpbHkgZm9yIHF1YWxpdHkgdXNpbmcgdmFyaW91cyB0ZWNobmlxdWVzLCBpbmNsdWRpbmcgaGV1cmlzdGljIGZpbHRlcnMsIE5TRlcgZmlsdGVycywgYW5kIHRleHQgY2xhc3NpZmllcnMuIFRoZSBtb2RlbCdzIGtub3dsZWRnZSB3YXMgdHJhaW5lZCBvbiBkYXRhIHdpdGggYSBjdXRvZmYgb2YgRGVjZW1iZXIgMjAyM1xcLiBcblxuIyMjICoqVGVzdGluZyBEYXRhc2V0KipcblxuKipMaW5rOioqIFVuZGlzY2xvc2VkXG5cbioqRGF0YSBDb2xsZWN0aW9uIE1ldGhvZDoqKiBIeWJyaWQ6IEh1bWFuLCBTeW50aGV0aWMsIEF1dG9tYXRlZFxuXG4qKkxhYmVsaW5nIE1ldGhvZDoqKiBIeWJyaWQ6IEF1dG9tYXRlZCwgSHVtYW5cblxuKipQcm9wZXJ0aWVzOioqIFxuXG4qKkRlc2NyaXB0aW9uOioqXG5cblRoZSBtb2RlbCB3YXMgdGVzdGVkIG9uIGEgZGl2ZXJzZSBzZXQgb2YgZXZhbHVhdGlvbiBkYXRhLlxuXG4qIFB1YmxpYyBCZW5jaG1hcmtzOiBUaGVzZSB0ZXN0IGEgd2lkZSByYW5nZSBvZiBjYXBhYmlsaXRpZXMsIGZyb20gZ2VuZXJhbCBrbm93bGVkZ2UgYW5kIHJlYXNvbmluZyAoTU1MVSwgSGVsbGFTd2FnKSB0byBleHBlcnQtbGV2ZWwgcHJvYmxlbS1zb2x2aW5nIChHUFFBKSBhbmQgcHJvZ3JhbW1pbmcgKEh1bWFuRXZhbCwgd2hpY2ggY29udGFpbnMgMTY0IHByb2dyYW1taW5nIHByb2JsZW1zKS4gIFxuKiBJbnRlcm5hbCBFdmFsdWF0aW9uIFNldDogTWV0YSBjcmVhdGVkIGEgbmV3IGhpZ2gtcXVhbGl0eSB0ZXN0IHNldCBvZiAyLDAwMCBwcm9tcHRzIGNvdmVyaW5nIDEyIGtleSB1c2UgY2FzZXMgKGUuZy4sIGNvZGluZywgcmVhc29uaW5nLCBjcmVhdGl2ZSB3cml0aW5nLCBpbnN0cnVjdGlvbiBmb2xsb3dpbmcpLiBUaGlzIHNldCBpcyB1c2VkIGZvciBodW1hbiBldmFsdWF0aW9uIHRvIGFzc2VzcyBwZXJmb3JtYW5jZSBvbiByZWFsLXdvcmxkLCBudWFuY2VkIHRhc2tzLiBcblxuIyMjICoqRXZhbHVhdGlvbiBEYXRhc2V0KipcblxuKipMaW5rOioqIFVuZGlzY2xvc2VkXG5cbioqRGF0YSBDb2xsZWN0aW9uIE1ldGhvZDoqKiBIeWJyaWQ6IEF1dG9tYXRlZCwgSHVtYW4sIFN5bnRoZXRpY1xuXG4qKkxhYmVsaW5nIE1ldGhvZDoqKiBIeWJyaWQ6IEh1bWFuLCBBdXRvbWF0ZWRcblxuKipQcm9wZXJ0aWVzOioqIFxuXG5UaGUgZXZhbHVhdGlvbiBkYXRhc2V0cyBhcmUgZGl2ZXJzZSBhbmQgdGVzdCBhIHdpZGUgc3BlY3RydW0gb2YgY2FwYWJpbGl0aWVzLiBNTUxVIG1lYXN1cmVzIGJyb2FkIG11bHRpdGFzayBrbm93bGVkZ2UuIEdQUUEgYXNzZXNzZXMgYWR2YW5jZWQgcmVhc29uaW5nIHdpdGggZGlmZmljdWx0LCBleHBlcnQtbGV2ZWwgcXVlc3Rpb25zLiBIdW1hbkV2YWwgYW5kIE1BVEggc3BlY2lmaWNhbGx5IHRlc3QgY29kZSBnZW5lcmF0aW9uIGFuZCBtYXRoZW1hdGljYWwgcmVhc29uaW5nIGFiaWxpdGllcywgcmVzcGVjdGl2ZWx5LiBNZXRhIGFsc28gdXRpbGl6ZXMgYSBsYXJnZSwgcHJpdmF0ZSwgaHVtYW4tYW5ub3RhdGVkIGV2YWx1YXRpb24gc2V0IGRlc2lnbmVkIHRvIGFzc2VzcyBtb2RlbCBwZXJmb3JtYW5jZSBpbiByZWFsLXdvcmxkLCBudWFuY2VkIHNjZW5hcmlvcy4gXG5cbioqQmFzZSBwcmV0cmFpbmVkIG1vZGVscyoqXG5cbnwgQ2F0ZWdvcnkgfCBCZW5jaG1hcmsgfCBcXCMgU2hvdHMgfCBNZXRyaWMgfCBMbGFtYSAzIDhCIHwgTGxhbWEgMy4xIDhCIHwgTGxhbWEgMyA3MEIgfCBMbGFtYSAzLjEgNzBCIHwgTGxhbWEgMy4xIDQwNUIgfFxufCA6LS0tLSB8IDotLS0tIHwgOi0tLS0gfCA6LS0tLSB8IDotLS0tIHwgOi0tLS0gfCA6LS0tLSB8IDotLS0tIHwgOi0tLS0gfFxufCBHZW5lcmFsIHwgTU1MVSB8IDUgfCBtYWNyb1xcX2F2Zy9hY2NcXF9jaGFyIHwgNjYuNyB8IDY2LjcgfCA3OS41IHwgNzkuMyB8IDg1LjIgfFxufCAgfCBNTUxVLVBybyAoQ29UKSB8IDUgfCBtYWNyb1xcX2F2Zy9hY2NcXF9jaGFyIHwgMzYuMiB8IDM3LjEgfCA1NS4wIHwgNTMuOCB8IDYxLjYgfFxufCAgfCBBR0lFdmFsIEVuZ2xpc2ggfCAzLTUgfCBhdmVyYWdlL2FjY1xcX2NoYXIgfCA0Ny4xIHwgNDcuOCB8IDYzLjAgfCA2NC42IHwgNzEuNiB8XG58ICB8IENvbW1vblNlbnNlUUEgfCA3IHwgYWNjXFxfY2hhciB8IDcyLjYgfCA3NS4wIHwgODMuOCB8IDg0LjEgfCA4NS44IHxcbnwgIHwgV2lub2dyYW5kZSB8IDUgfCBhY2NcXF9jaGFyIHwgXFwtIHwgNjAuNSB8IFxcLSB8IDgzLjMgfCA4Ni43IHxcbnwgIHwgQklHLUJlbmNoIEhhcmQgKENvVCkgfCAzIHwgYXZlcmFnZS9lbSB8IDYxLjEgfCA2NC4yIHwgODEuMyB8IDgxLjYgfCA4NS45IHxcbnwgIHwgQVJDLUNoYWxsZW5nZSB8IDI1IHwgYWNjXFxfY2hhciB8IDc5LjQgfCA3OS43IHwgOTMuMSB8IDkyLjkgfCA5Ni4xIHxcbnwgS25vd2xlZGdlIHJlYXNvbmluZyB8IFRyaXZpYVFBLVdpa2kgfCA1IHwgZW0gfCA3OC41IHwgNzcuNiB8IDg5LjcgfCA4OS44IHwgOTEuOCB8XG58IFJlYWRpbmcgY29tcHJlaGVuc2lvbiB8IFNRdUFEIHwgMSB8IGVtIHwgNzYuNCB8IDc3LjAgfCA4NS42IHwgODEuOCB8IDg5LjMgfFxufCAgfCBRdUFDIChGMSkgfCAxIHwgZjEgfCA0NC40IHwgNDQuOSB8IDUxLjEgfCA1MS4xIHwgNTMuNiB8XG58ICB8IEJvb2xRIHwgMCB8IGFjY1xcX2NoYXIgfCA3NS43IHwgNzUuMCB8IDc5LjAgfCA3OS40IHwgODAuMCB8XG58ICB8IERST1AgKEYxKSB8IDMgfCBmMSB8IDU4LjQgfCA1OS41IHwgNzkuNyB8IDc5LjYgfCA4NC44IHxcblxuKipJbnN0cnVjdGlvbiB0dW5lZCBtb2RlbHMqKlxuXG58IENhdGVnb3J5IHwgQmVuY2htYXJrIHwgXFwjIFNob3RzIHwgTWV0cmljIHwgTGxhbWEgMyA4QiBJbnN0cnVjdCB8IExsYW1hIDMuMSA4QiBJbnN0cnVjdCB8IExsYW1hIDMgNzBCIEluc3RydWN0IHwgTGxhbWEgMy4xIDcwQiBJbnN0cnVjdCB8IExsYW1hIDMuMSA0MDVCIEluc3RydWN0IHxcbnwgOi0tLS0gfCA6LS0tLSB8IDotLS0tIHwgOi0tLS0gfCA6LS0tLSB8IDotLS0tIHwgOi0tLS0gfCA6LS0tLSB8IDotLS0tIHxcbnwgR2VuZXJhbCB8IE1NTFUgfCA1IHwgbWFjcm9cXF9hdmcvYWNjIHwgNjguNSB8IDY5LjQgfCA4Mi4wIHwgODMuNiB8IDg3LjMgfFxufCAgfCBNTUxVIChDb1QpIHwgMCB8IG1hY3JvXFxfYXZnL2FjYyB8IDY1LjMgfCA3My4wIHwgODAuOSB8IDg2LjAgfCA4OC42IHxcbnwgIHwgTU1MVS1Qcm8gKENvVCkgfCA1IHwgbWljcm9cXF9hdmcvYWNjXFxfY2hhciB8IDQ1LjUgfCA0OC4zIHwgNjMuNCB8IDY2LjQgfCA3My4zIHxcbnwgIHwgSUZFdmFsIHwgIHwgIHwgNzYuOCB8IDgwLjQgfCA4Mi45IHwgODcuNSB8IDg4LjYgfFxufCBSZWFzb25pbmcgfCBBUkMtQyB8IDAgfCBhY2MgfCA4Mi40IHwgODMuNCB8IDk0LjQgfCA5NC44IHwgOTYuOSB8XG58ICB8IEdQUUEgfCAwIHwgZW0gfCAzNC42IHwgMzAuNCB8IDM5LjUgfCA0Ni43IHwgNTAuNyB8XG58IENvZGUgfCBIdW1hbkV2YWwgfCAwIHwgcGFzc0AxIHwgNjAuNCB8IDcyLjYgfCA4MS43IHwgODAuNSB8IDg5LjAgfFxufCAgfCBNQlBQIFxcKysgYmFzZSB2ZXJzaW9uIHwgMCB8IHBhc3NAMSB8IDcwLjYgfCA3Mi44IHwgODIuNSB8IDg2LjAgfCA4OC42IHxcbnwgIHwgTXVsdGlwbC1FIEh1bWFuRXZhbCB8IDAgfCBwYXNzQDEgfCBcXC0gfCA1MC44IHwgXFwtIHwgNjUuNSB8IDc1LjIgfFxufCAgfCBNdWx0aXBsLUUgTUJQUCB8IDAgfCBwYXNzQDEgfCBcXC0gfCA1Mi40IHwgXFwtIHwgNjIuMCB8IDY1LjcgfFxufCBNYXRoIHwgR1NNLThLIChDb1QpIHwgOCB8IGVtXFxfbWFqMUAxIHwgODAuNiB8IDg0LjUgfCA5My4wIHwgOTUuMSB8IDk2LjggfFxufCAgfCBNQVRIIChDb1QpIHwgMCB8IGZpbmFsXFxfZW0gfCAyOS4xIHwgNTEuOSB8IDUxLjAgfCA2OC4wIHwgNzMuOCB8XG58IFRvb2wgVXNlIHwgQVBJLUJhbmsgfCAwIHwgYWNjIHwgNDguMyB8IDgyLjYgfCA4NS4xIHwgOTAuMCB8IDkyLjAgfFxufCAgfCBCRkNMIHwgMCB8IGFjYyB8IDYwLjMgfCA3Ni4xIHwgODMuMCB8IDg0LjggfCA4OC41IHxcbnwgIHwgR29yaWxsYSBCZW5jaG1hcmsgQVBJIEJlbmNoIHwgMCB8IGFjYyB8IDEuNyB8IDguMiB8IDE0LjcgfCAyOS43IHwgMzUuMyB8XG58ICB8IE5leHVzICgwLXNob3QpIHwgMCB8IG1hY3JvXFxfYXZnL2FjYyB8IDE4LjEgfCAzOC41IHwgNDcuOCB8IDU2LjcgfCA1OC43IHxcbnwgTXVsdGlsaW5ndWFsIHwgTXVsdGlsaW5ndWFsIE1HU00gKENvVCkgfCAwIHwgZW0gfCBcXC0gfCA2OC45IHwgXFwtIHwgODYuOSB8IDkxLjYgfFxuXG4qKk11bHRpbGluZ3VhbCBiZW5jaG1hcmtzKipcblxufCBDYXRlZ29yeSB8IEJlbmNobWFyayB8IExhbmd1YWdlIHwgTGxhbWEgMy4xIDhCIHwgTGxhbWEgMy4xIDcwQiB8IExsYW1hIDMuMSA0MDVCIHxcbnwgOi0tLS0gfCA6LS0tLSB8IDotLS0tIHwgOi0tLS0gfCA6LS0tLSB8IDotLS0tIHxcbnwgR2VuZXJhbCB8IE1NTFUgKDUtc2hvdCwgbWFjcm9cXF9hdmcvYWNjKSB8IFBvcnR1Z3Vlc2UgfCA2Mi4xMiB8IDgwLjEzIHwgODQuOTUgfFxufCAgfCAgfCBTcGFuaXNoIHwgNjIuNDUgfCA4MC4wNSB8IDg1LjA4IHxcbnwgIHwgIHwgSXRhbGlhbiB8IDYxLjYzIHwgODAuNCB8IDg1LjA0IHxcbnwgIHwgIHwgR2VybWFuIHwgNjAuNTkgfCA3OS4yNyB8IDg0LjM2IHxcbnwgIHwgIHwgRnJlbmNoIHwgNjIuMzQgfCA3OS44MiB8IDg0LjY2IHxcbnwgIHwgIHwgSGluZGkgfCA1MC44OCB8IDc0LjUyIHwgODAuMzEgfFxufCAgfCAgfCBUaGFpIHwgNTAuMzIgfCA3Mi45NSB8IDc4LjIxIHxcblxuIyMgKipUZWNobmljYWwgTGltaXRhdGlvbnMqKiBcblxuVGVzdGluZyBjb25kdWN0ZWQgdG8gZGF0ZSBoYXMgbm90IGNvdmVyZWQsIG5vciBjb3VsZCBpdCBjb3ZlciwgYWxsIHNjZW5hcmlvcy4gRm9yIHRoZXNlIHJlYXNvbnMsIGFzIHdpdGggYWxsIExMTXMsIHRoZSBtb2RlbCdzIHBvdGVudGlhbCBvdXRwdXRzIGNhbm5vdCBiZSBwcmVkaWN0ZWQgaW4gYWR2YW5jZSwgYW5kIHRoZSBtb2RlbCBtYXkgaW4gc29tZSBpbnN0YW5jZXMgcHJvZHVjZSBpbmFjY3VyYXRlLCBiaWFzZWQgb3Igb3RoZXIgb2JqZWN0aW9uYWJsZSByZXNwb25zZXMgdG8gdXNlciBwcm9tcHRzLiBUaGVyZWZvcmUsIGJlZm9yZSBkZXBsb3lpbmcgdGhpcyBtb2RlbCBpbiBhbnkgYXBwbGljYXRpb25zLCBkZXZlbG9wZXJzIHNob3VsZCBwZXJmb3JtIHNhZmV0eSB0ZXN0aW5nIGFuZCB0dW5pbmcgdGFpbG9yZWQgdG8gdGhlaXIgc3BlY2lmaWMgYXBwbGljYXRpb25zLiBQbGVhc2UgcmVmZXIgdG8gYXZhaWxhYmxlIHJlc291cmNlcyBpbmNsdWRpbmcgdGhlIFtSZXNwb25zaWJsZSBVc2UgR3VpZGVdKGh0dHBzOi8vbGxhbWEubWV0YS5jb20vcmVzcG9uc2libGUtdXNlLWd1aWRlKSwgW1RydXN0IGFuZCBTYWZldHldKGh0dHBzOi8vbGxhbWEubWV0YS5jb20vdHJ1c3QtYW5kLXNhZmV0eS8pIHNvbHV0aW9ucywgYW5kIG90aGVyIFtyZXNvdXJjZXNdKGh0dHBzOi8vbGxhbWEubWV0YS5jb20vZG9jcy9nZXQtc3RhcnRlZC8pIHRvIGxlYXJuIG1vcmUgYWJvdXQgcmVzcG9uc2libGUgZGV2ZWxvcG1lbnQuIFxuXG4jIyAqKkluZmVyZW5jZToqKlxuXG4qKkFjY2VsZXJhdGlvbiBFbmdpbmU6KiogdkxMTSwgVGVuc29yUlQgXG5cbioqVGVzdCBIYXJkd2FyZToqKiBcblxuICBCMjAwIFNYTSAgIFxuICBIMjAwIFNYTSAgXG4gIEgxMDAgU1hNICBcbiAgQTEwMCBTWE0gODBHQiAgXG4gIEExMDAgU1hNIDQwR0IgIFxuICBMNDBTIFBDSWUgIFxuICBBMTBHICBcbiAgSDEwMCBOVkwgIFxuICBIMjAwIE5WTCAgXG4gIEdIMjAwIDk2R0IgIFxuICBHQjIwMCBOVkw3MiAgIFxuICBHSDIwMCBOVkwyICAgICBcbiAgUlRYIDUwOTAgIFxuICBSVFggNDA5MCAgXG4gIFJUWCA2MDAwIEFkYVxuXG4jIyAqKkV0aGljYWwgQ29uc2lkZXJhdGlvbnM6KipcblxuTlZJRElBIGJlbGlldmVzIFRydXN0d29ydGh5IEFJIGlzIGEgc2hhcmVkIHJlc3BvbnNpYmlsaXR5IGFuZCB3ZSBoYXZlIGVzdGFibGlzaGVkIHBvbGljaWVzIGFuZCBwcmFjdGljZXMgdG8gZW5hYmxlIGRldmVsb3BtZW50IGZvciBhIHdpZGUgYXJyYXkgb2YgQUkgYXBwbGljYXRpb25zLiBXaGVuIGRvd25sb2FkZWQgb3IgdXNlZCBpbiBhY2NvcmRhbmNlIHdpdGggb3VyIHRlcm1zIG9mIHNlcnZpY2UsIGRldmVsb3BlcnMgc2hvdWxkIHdvcmsgd2l0aCB0aGVpciBpbnRlcm5hbCBtb2RlbCB0ZWFtIHRvIGVuc3VyZSB0aGlzIG1vZGVsIG1lZXRzIHJlcXVpcmVtZW50cyBmb3IgdGhlIHJlbGV2YW50IGluZHVzdHJ5IGFuZCB1c2UgY2FzZSBhbmQgYWRkcmVzc2VzIHVuZm9yZXNlZW4gcHJvZHVjdCBtaXN1c2UuIFBsZWFzZSByZXBvcnQgc2VjdXJpdHkgdnVsbmVyYWJpbGl0aWVzIG9yIE5WSURJQSBBSSBDb25jZXJucyBbaGVyZV0oaHR0cHM6Ly93d3cubnZpZGlhLmNvbS9lbi11cy9zdXBwb3J0L3N1Ym1pdC1zZWN1cml0eS12dWxuZXJhYmlsaXR5LykuXG5cbllvdSBhcmUgcmVzcG9uc2libGUgZm9yIGVuc3VyaW5nIHRoYXQgeW91ciB1c2Ugb2YgTlZJRElBIHByb3ZpZGVkIG1vZGVscyBjb21wbGllcyB3aXRoIGFsbCBhcHBsaWNhYmxlIGxhd3MuIiwKICAgICJkaXNwbGF5TmFtZSI6ICJMbGFtYS0zLjEtNzBiLWluc3RydWN0IiwKICAgICJleHBsYWluYWJpbGl0eSI6ICIiLAogICAgImZyYW1ld29yayI6ICJPdGhlciIsCiAgICAiaGFzUGxheWdyb3VuZCI6IGZhbHNlLAogICAgImhhc1NpZ25lZFZlcnNpb24iOiB0cnVlLAogICAgImlzUGxheWdyb3VuZEVuYWJsZWQiOiBmYWxzZSwKICAgICJpc1B1YmxpYyI6IGZhbHNlLAogICAgImlzUmVhZE9ubHkiOiB0cnVlLAogICAgImxhYmVscyI6IFsKICAgICAgICAiTGxhbWEzLjEiLAogICAgICAgICJMbGFtYTMuMS03MGItaW5zdHJ1Y3QiLAogICAgICAgICJOSU0iLAogICAgICAgICJOU1BFQ1QtN1MzRi1RRkc4IiwKICAgICAgICAibnZhaWU6bW9kZWw6bnZhaWVfc3VwcG9ydGVkIiwKICAgICAgICAibnZpZGlhX25pbTptb2RlbDpuaW1tY3JvX252aWRpYV9uaW0iLAogICAgICAgICJwcm9kdWN0TmFtZXM6bmltLWRldiIsCiAgICAgICAgInByb2R1Y3ROYW1lczpudi1haS1lbnRlcnByaXNlIgogICAgXSwKICAgICJsYXRlc3RWZXJzaW9uSWRTdHIiOiAicnR4NjAwMC1ibGFja3dlbGwtc3Z4OC1sYXRlbmN5LWJmMTYtYnhpYWdoNGpnZyIsCiAgICAibGF0ZXN0VmVyc2lvblNpemVJbkJ5dGVzIjogMTU3MzU3MjY3OTI3LAogICAgImxvZ28iOiAiaHR0cHM6Ly9hc3NldHMubmdjLm52aWRpYS5jb20vcHJvZHVjdHMvYXBpLWNhdGFsb2cvaW1hZ2VzL2xsYW1hLTNfMS03MGItaW5zdHJ1Y3QuanBnIiwKICAgICJtb2RlbEZvcm1hdCI6ICJTYXZlZE1vZGVsIiwKICAgICJuYW1lIjogImxsYW1hLTMuMS03MGItaW5zdHJ1Y3QiLAogICAgIm9yZ05hbWUiOiAibmltIiwKICAgICJwcmVjaXNpb24iOiAiT1RIRVIiLAogICAgInByaXZhY3kiOiAiIiwKICAgICJwcm9kdWN0TmFtZXMiOiBbCiAgICAgICAgIm5pbS1kZXYiLAogICAgICAgICJudi1haS1lbnRlcnByaXNlIgogICAgXSwKICAgICJwdWJsaWNEYXRhc2V0VXNlZCI6IHt9LAogICAgInB1Ymxpc2hlciI6ICJNZXRhIiwKICAgICJzYWZldHlBbmRTZWN1cml0eSI6ICIiLAogICAgInNob3J0RGVzY3JpcHRpb24iOiAiVGhlIE1ldGEgTGxhbWEgMy4xIGNvbGxlY3Rpb24gb2YgbXVsdGlsaW5ndWFsIGxhcmdlIGxhbmd1YWdlIG1vZGVscyAoTExNcykgaXMgYSBjb2xsZWN0aW9uIG9mIHByZXRyYWluZWQgYW5kIGluc3RydWN0aW9uIHR1bmVkIGdlbmVyYXRpdmUgbW9kZWxzIGluIDhCLCA3MEIgYW5kIDQwNUIgc2l6ZXMgKHRleHQgaW4vdGV4dCBvdXQpLiIsCiAgICAidGVhbU5hbWUiOiAibWV0YSIsCiAgICAidXBkYXRlZERhdGUiOiAiMjAyNS0xMC0xNVQxNzo0OToxNS42MDVaIgp9
     source:
@@ -1616,6 +1857,315 @@ models:
         value: 263GB
       - key: LLM ENGINE
         value: VLLM
+    - profileId: nim/meta/llama-3.1-70b-instruct-pb25h2:1d54af340dc8906a2d21146191a9c184c35e47bd-rtx6000_blackwell_sv-tp2__3
+      framework: VLLM
+      displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx2 BF16
+      ngcMetadata:
+        39194b5f5858f2dde376844651af70e4471874a29935142320b972a2e3ca0ac5:
+          model: meta/llama-3.1-70b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'true'
+            feat_lora_max_rank: '32'
+            llm_engine: vllm
+            nim_workspace_hash_v1: 299821baf3058c03febd8fbfe6422d1342d72bee844f4d66ca27c24a3b190c0d
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 263GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.1-70b-instruct-pb25h2:1d54af340dc8906a2d21146191a9c184c35e47bd-rtx6000_blackwell_sv-tp2
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx2 FP8 Throughput
+      ngcMetadata:
+        bc57e25851a04ff1f855d632d2f656c8eb1a137e55eba2063adcb8ce1116069d:
+          model: meta/llama-3.1-70b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 43974cb445b2cc0a952d77e6a01d557c0fe4f2a3cc1c35796a1043c57518d3cf
+            number_of_gpus: '2'
+            pp: '1'
+            precision: fp8
+            profile: throughput
+            tp: '2'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: THROUGHPUT
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 263GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/meta/llama-3.1-70b-instruct-pb25h2:1d54af340dc8906a2d21146191a9c184c35e47bd-rtx6000_blackwell_sv-tp2__2
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx2 NVFP4 Throughput
+      ngcMetadata:
+        cab042186e90569e93c02348e34628537983e52ab710d3a4fdf42fc9fa4c569b:
+          model: meta/llama-3.1-70b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 6e54117bf7b0c8b928a004a7b02ae040230bdf0fb2670a5499a6b86de772bf59
+            number_of_gpus: '2'
+            pp: '1'
+            precision: nvfp4
+            profile: throughput
+            tp: '2'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: THROUGHPUT
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 263GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/meta/llama-3.1-70b-instruct-pb25h2:1d54af340dc8906a2d21146191a9c184c35e47bd-rtx6000_blackwell_sv-tp4__4
+      framework: VLLM
+      displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx4 BF16
+      ngcMetadata:
+        006abfcad3d12cfc6571d2e55f09a58957a0e3a5cd39c2df8c10e78f4ce10978:
+          model: meta/llama-3.1-70b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'true'
+            feat_lora_max_rank: '32'
+            llm_engine: vllm
+            nim_workspace_hash_v1: 299821baf3058c03febd8fbfe6422d1342d72bee844f4d66ca27c24a3b190c0d
+            pp: '1'
+            precision: bf16
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 263GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.1-70b-instruct-pb25h2:1d54af340dc8906a2d21146191a9c184c35e47bd-rtx6000_blackwell_sv-tp4__3
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx4 BF16 Throughput
+      ngcMetadata:
+        d917ec97b8b2584fe655c03e9152f33e1e1a485c90b8ced5098787bbcf196c7b:
+          model: meta/llama-3.1-70b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 8dc56a001e709d604284f145342698a414d54dc087b26f2fd39628b586819e8a
+            number_of_gpus: '4'
+            pp: '1'
+            precision: bf16
+            profile: throughput
+            tp: '4'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: THROUGHPUT
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 263GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/meta/llama-3.1-70b-instruct-pb25h2:1d54af340dc8906a2d21146191a9c184c35e47bd-rtx6000_blackwell_sv-tp4
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx4 FP8 Latency
+      ngcMetadata:
+        64bc125ba10664e556b2e4203702c2be799df905a26f16724dc5a5933dbad919:
+          model: meta/llama-3.1-70b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: eab1d9b2ac2520726f1218f41491e57157abcd21ba738a45b37deaa206384073
+            number_of_gpus: '4'
+            pp: '1'
+            precision: fp8
+            profile: latency
+            tp: '4'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: LATENCY
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 263GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/meta/llama-3.1-70b-instruct-pb25h2:1d54af340dc8906a2d21146191a9c184c35e47bd-rtx6000_blackwell_sv-tp4__2
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx4 NVFP4 Latency
+      ngcMetadata:
+        6a59fd6976eb5dc3d7c05f45c35f5aa5de00174b41957767c73c0034d91122e1:
+          model: meta/llama-3.1-70b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: bcb143d582f4a6c76551d735a1b403a716abe7d0bc20cf00d98d8c86ceb2dfe0
+            number_of_gpus: '4'
+            pp: '1'
+            precision: nvfp4
+            profile: latency
+            tp: '4'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: LATENCY
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 263GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/meta/llama-3.1-70b-instruct-pb25h2:1d54af340dc8906a2d21146191a9c184c35e47bd-rtx6000_blackwell_sv-tp8__2
+      framework: VLLM
+      displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx8 BF16
+      ngcMetadata:
+        3dcc4db7b5b522f47bf5c344038e6c8cad918617f954a0b751c9b7fcc5bb4d3f:
+          model: meta/llama-3.1-70b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'true'
+            feat_lora_max_rank: '32'
+            llm_engine: vllm
+            nim_workspace_hash_v1: 299821baf3058c03febd8fbfe6422d1342d72bee844f4d66ca27c24a3b190c0d
+            pp: '1'
+            precision: bf16
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 263GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.1-70b-instruct-pb25h2:1d54af340dc8906a2d21146191a9c184c35e47bd-rtx6000_blackwell_sv-tp8
+      framework: TensorRT-LLM
+      displayName: Llama 3.1 70B Instruct RTX6000_BLACKWELL_SVx8 BF16 Latency
+      ngcMetadata:
+        9eb233c7c0ee4da16616a30996ab9a65e9b5405708df3a19a06da04ac8a78495:
+          model: meta/llama-3.1-70b-instruct
+          release: 1.14.0-pb5.5-stig-fips-x86-64
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: b84e4f23dec2af9146539c7f2865430fe42d7359aa1b3877c6beb286f0ef8558
+            number_of_gpus: '8'
+            pp: '1'
+            precision: bf16
+            profile: latency
+            tp: '8'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: LATENCY
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.14.0-pb5.5-stig-fips-x86-64
+      - key: DOWNLOAD SIZE
+        value: 263GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
   labels:
   - Llama
   - Meta

--- a/models/public/llama-3.3-instruct.yaml
+++ b/models/public/llama-3.3-instruct.yaml
@@ -2017,6 +2017,366 @@ models:
         value: 40GB
       - key: LLM ENGINE
         value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:bf16-6f6073b423013f6a7d4d9f39144961bfbfbc386b-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx1 BF16
+      ngcMetadata:
+        120f37d15ce21955b951e9acef346dcdcc0ebb17b9e09c1eef15e803a8b87665:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '174.0'
+            pp: '1'
+            precision: bf16
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 132GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:fp8-rxbjb-qrcq-tool-calling-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx1 FP8
+      ngcMetadata:
+        9dad49c0ef76f964e9295d8071045f0c6a2b52ffdc9cb11b8887adced9370554:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '111.0'
+            pp: '1'
+            precision: fp8
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 68GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:nvfp4-klvd4-nzbq-tool-calling-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx1 NVFP4
+      ngcMetadata:
+        13b2cabe93f6e3d81e056b10d747d4baffc8dc6708977963dbc02c378fe6e7fd:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '82.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 40GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:bf16-6f6073b423013f6a7d4d9f39144961bfbfbc386b-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx2 BF16
+      ngcMetadata:
+        314bf2e552c132bc56ed8503d5bd9f3c159abe5c9ca8a694e5e2081eb7c04649:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '89.0'
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 132GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:fp8-rxbjb-qrcq-tool-calling-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx2 FP8
+      ngcMetadata:
+        74dc099acf027ca44ed08bf7f182582f4f20bef8c9be768908a3a11f55a4803d:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '57.0'
+            pp: '1'
+            precision: fp8
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 68GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:nvfp4-klvd4-nzbq-tool-calling-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx2 NVFP4
+      ngcMetadata:
+        313ac0ae8b3d63007c5c3af22b90e3371d99332aff7a8d19162c0a5dfaaeade5:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '43.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 40GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:bf16-6f6073b423013f6a7d4d9f39144961bfbfbc386b-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx4 BF16
+      ngcMetadata:
+        128b00593671377d1f538c52b7c83d57f6d0bee57b32af3143368a7fe246afea:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '47.0'
+            pp: '1'
+            precision: bf16
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 132GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:fp8-rxbjb-qrcq-tool-calling-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx4 FP8
+      ngcMetadata:
+        16bb57d5dfa4bd677567955d1d4d6977b8bd1f9260139a5cce29ea7a7299b85f:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '31.0'
+            pp: '1'
+            precision: fp8
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 68GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:nvfp4-klvd4-nzbq-tool-calling-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx4 NVFP4
+      ngcMetadata:
+        b99f21d2c604622d124cbd2f922f523bd695690693f43b9dbd0937d43e43922c:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '24.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 40GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:bf16-6f6073b423013f6a7d4d9f39144961bfbfbc386b-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx8 BF16
+      ngcMetadata:
+        2914d34f4fa4833f89591ad3d5f92257d2167acb8ddb298a7ea0ad69629dbb16:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '25.0'
+            pp: '1'
+            precision: bf16
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 132GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:fp8-rxbjb-qrcq-tool-calling-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx8 FP8
+      ngcMetadata:
+        639213f8d80b20fddf456aa7c2e456b3d175b4043d1d5f1694a680757a25dad3:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '18.0'
+            pp: '1'
+            precision: fp8
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 68GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/meta/llama-3.3-70b-instruct:nvfp4-klvd4-nzbq-tool-calling-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Llama 3.3 70B Instruct RTX6000_BLACKWELL_SVx8 NVFP4
+      ngcMetadata:
+        218de288d43ccaf69332f22c8826ead532723b7de3fbdd294b61051a3f1c83c6:
+          model: meta/llama-3.3-70b-instruct
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '15.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 40GB
+      - key: LLM ENGINE
+        value: VLLM
   labels:
   - Llama
   - Meta

--- a/models/public/llama-3.3-nemotron-super-49b.yaml
+++ b/models/public/llama-3.3-nemotron-super-49b.yaml
@@ -2081,6 +2081,366 @@ models:
         value: 29GB
       - key: LLM ENGINE
         value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-checkpoint-bf16-jetart-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx1 BF16
+      ngcMetadata:
+        8c3925b338d0bda8a4c95533c8c39e8ba9d38c2c7d4c687dd9fbc091186fccc1:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '120.0'
+            pp: '1'
+            precision: bf16
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 93GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:fp8-rmctserfba-tool-calling-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx1 FP8
+      ngcMetadata:
+        442b97776dbd568ef529479d866b000c7bd16b5f5d2422c213a0b3b1624c9281:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '76.0'
+            pp: '1'
+            precision: fp8
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 49GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:nvfp4-biyprhc44a-tool-calling-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx1 NVFP4
+      ngcMetadata:
+        50e2f862b5fe96cba5e45e2092d38845fa54104dcc03f4c0b2bdb23b4d05b6aa:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '56.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 29GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-checkpoint-bf16-jetart-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx2 BF16
+      ngcMetadata:
+        1146f49f84dff5dea09f5aa633cc70b92d7d972223d67878c841cd0fbccad4fb:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '62.0'
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 93GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:fp8-rmctserfba-tool-calling-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx2 FP8
+      ngcMetadata:
+        539eab4f3514e65516789d3bd11e4102aae5065a86e7cfb7688950bb456ce239:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '40.0'
+            pp: '1'
+            precision: fp8
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 49GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:nvfp4-biyprhc44a-tool-calling-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx2 NVFP4
+      ngcMetadata:
+        1952dc27de2122a4aadff950e4f7c6f7f383cdc63500c6bb483cc4d7fc930196:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '30.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 29GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-checkpoint-bf16-jetart-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx4 BF16
+      ngcMetadata:
+        6ffcc333dec0c7f62e8589513d5682d1268f47c552f6fc978080dd2c30389ba8:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '33.0'
+            pp: '1'
+            precision: bf16
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 93GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:fp8-rmctserfba-tool-calling-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx4 FP8
+      ngcMetadata:
+        18c1c9566d039d78881db55dd30907348afd73ff75f4e262aa1af824e320aa55:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '22.0'
+            pp: '1'
+            precision: fp8
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 49GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:nvfp4-biyprhc44a-tool-calling-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx4 NVFP4
+      ngcMetadata:
+        5122caf75c64b197b8d2170464500fd2aab69aa4d66c278629f7894271ca3ab9:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '17.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 29GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:hf-checkpoint-bf16-jetart-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx8 BF16
+      ngcMetadata:
+        c7e34d09ffb6939d600faab0b43370ae4527cb008f2635464a53d9b46a368b27:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '19.0'
+            pp: '1'
+            precision: bf16
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 93GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:fp8-rmctserfba-tool-calling-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx8 FP8
+      ngcMetadata:
+        651f21dff2c1193dd7e606701ad1e18d5e35fe0cdc597f0b08a4af2609824af1:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '13.0'
+            pp: '1'
+            precision: fp8
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 49GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/llama-3.3-nemotron-super-49b-v1.5:nvfp4-biyprhc44a-tool-calling-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Llama 3.3 Nemotron Super 49B V1.5 RTX6000_BLACKWELL_SVx8 NVFP4
+      ngcMetadata:
+        32dcea516a998a70f3069cdfbcc781de6c492c344cb38a29780f249fdb190e4d:
+          model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '11.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 29GB
+      - key: LLM ENGINE
+        value: VLLM
   labels:
   - Llama
   - Meta

--- a/models/public/minimax-m25.yaml
+++ b/models/public/minimax-m25.yaml
@@ -647,6 +647,108 @@ models:
         value: 215GB
       - key: LLM ENGINE
         value: SGLANG
+    - profileId: nim/minimax-ai/minimax-m25:hf-3040beaf-nim-rtx6000_blackwell_sv-tp2
+      framework: SGLang
+      displayName: Minimax M25 RTX6000_BLACKWELL_SVx2 FP8 Fallback
+      ngcMetadata:
+        2605f42cb4d0b90a89f44cfc23971278d95665b988d6d94b7e9b06326c21598f:
+          model: minimax-ai/minimax-m25
+          release: 1.7.1
+          tags:
+            ep: '1'
+            feat_lora: 'false'
+            llm_engine: sglang
+            pp: '1'
+            precision: fp8
+            profile: fallback
+            tp: '2'
+            vram: 300GiB
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: sglang
+      spec:
+      - key: PROFILE
+        value: FALLBACK
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 1.7.1
+      - key: DOWNLOAD SIZE
+        value: 215GB
+      - key: LLM ENGINE
+        value: SGLANG
+    - profileId: nim/minimax-ai/minimax-m25:hf-3040beaf-nim-rtx6000_blackwell_sv-tp4
+      framework: SGLang
+      displayName: Minimax M25 RTX6000_BLACKWELL_SVx4 FP8 Fallback
+      ngcMetadata:
+        15ebdb7833a74321359ccb332924083139a63677c5f16193f36f82874133b46a:
+          model: minimax-ai/minimax-m25
+          release: 1.7.1
+          tags:
+            ep: '1'
+            feat_lora: 'false'
+            llm_engine: sglang
+            pp: '1'
+            precision: fp8
+            profile: fallback
+            tp: '4'
+            vram: 300GiB
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: sglang
+      spec:
+      - key: PROFILE
+        value: FALLBACK
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 1.7.1
+      - key: DOWNLOAD SIZE
+        value: 215GB
+      - key: LLM ENGINE
+        value: SGLANG
+    - profileId: nim/minimax-ai/minimax-m25:hf-3040beaf-nim-rtx6000_blackwell_sv-tp8
+      framework: SGLang
+      displayName: Minimax M25 RTX6000_BLACKWELL_SVx8 FP8 Fallback
+      ngcMetadata:
+        ecc4f617f49bfa40d40c24eb3f0550233071bb62c387001be3155ee63c1a1ac0:
+          model: minimax-ai/minimax-m25
+          release: 1.7.1
+          tags:
+            ep: '8'
+            feat_lora: 'false'
+            llm_engine: sglang
+            pp: '1'
+            precision: fp8
+            profile: fallback
+            tp: '8'
+            vram: 300GiB
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: sglang
+      spec:
+      - key: PROFILE
+        value: FALLBACK
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 1.7.1
+      - key: DOWNLOAD SIZE
+        value: 215GB
+      - key: LLM ENGINE
+        value: SGLANG
   labels:
   - Multimodal
   - Minimax

--- a/models/public/mixtral-instruct.yaml
+++ b/models/public/mixtral-instruct.yaml
@@ -1303,6 +1303,274 @@ models:
         value: 87GB
       - key: LLM ENGINE
         value: VLLM
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v0-1:hf-a60832c-tool-use-v2-rtx6000_blackwell_sv__5
+      framework: VLLM
+      displayName: Mixtral 8x7b Instruct V0.1 RTX6000_BLACKWELL_SVx1 BF16
+      ngcMetadata:
+        61c1479f4e611effdbb853dbf3723f9f483f9261a16d05e67e8f122906bc9f05:
+          model: mistralai/mixtral-8x7b-instruct-v0.1
+          release: 1.12.0
+          tags:
+            feat_lora: 'true'
+            feat_lora_max_rank: '32'
+            llm_engine: vllm
+            nim_workspace_hash_v1: 1143086cd34eaa9e23556534ece80597734ec4653acf4ed38fc87f993b235371
+            pp: '1'
+            precision: bf16
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 1.12.0
+      - key: DOWNLOAD SIZE
+        value: 87GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v0-1:hf-a60832c-tool-use-v2-rtx6000_blackwell_sv
+      framework: TensorRT-LLM
+      displayName: Mixtral 8x7b Instruct V0.1 RTX6000_BLACKWELL_SVx1 BF16 Latency
+      ngcMetadata:
+        4de3615de4e17a52204267aa491eece5e2bf262b7e206e575629192e29905484:
+          model: mistralai/mixtral-8x7b-instruct-v0.1
+          release: 1.12.0
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 8746b88809968532d4e89e87a889301feb51db53963c629d5c8641f25cab7ef8
+            number_of_gpus: '1'
+            pp: '1'
+            precision: bf16
+            profile: latency
+            tp: '1'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: LATENCY
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.12.0
+      - key: DOWNLOAD SIZE
+        value: 87GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v0-1:hf-a60832c-tool-use-v2-rtx6000_blackwell_sv__4
+      framework: TensorRT-LLM
+      displayName: Mixtral 8x7b Instruct V0.1 RTX6000_BLACKWELL_SVx1 BF16 Throughput
+      ngcMetadata:
+        ffb72dbc582c757889db80e92ff451fbb41b7e2e282095011570664203059860:
+          model: mistralai/mixtral-8x7b-instruct-v0.1
+          release: 1.12.0
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: f3cadd31e5c7952a0e0240064b0a5d92eec6807465cc361c823f182252cd5e76
+            number_of_gpus: '1'
+            pp: '1'
+            precision: bf16
+            profile: throughput
+            tp: '1'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: THROUGHPUT
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.12.0
+      - key: DOWNLOAD SIZE
+        value: 87GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v0-1:hf-a60832c-tool-use-v2-rtx6000_blackwell_sv__3
+      framework: TensorRT-LLM
+      displayName: Mixtral 8x7b Instruct V0.1 RTX6000_BLACKWELL_SVx1 FP8 Latency
+      ngcMetadata:
+        eb79c173819637a1b1c609f26b732082affb7825871d5a6ba39eaa5ec516d18f:
+          model: mistralai/mixtral-8x7b-instruct-v0.1
+          release: 1.12.0
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 150c4a7f8276d0eeb355246dc21158e063c51d61015b972d77aed5189d9a62ec
+            number_of_gpus: '2'
+            pp: '1'
+            precision: fp8
+            profile: latency
+            tp: '1'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: LATENCY
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.12.0
+      - key: DOWNLOAD SIZE
+        value: 87GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v0-1:hf-a60832c-tool-use-v2-rtx6000_blackwell_sv__2
+      framework: TensorRT-LLM
+      displayName: Mixtral 8x7b Instruct V0.1 RTX6000_BLACKWELL_SVx1 FP8 Throughput
+      ngcMetadata:
+        9aa79b2cd14b16a6960827e7ec013a024d6236e6927ea63b276c7a4dc3b72964:
+          model: mistralai/mixtral-8x7b-instruct-v0.1
+          release: 1.12.0
+          tags:
+            feat_lora: 'false'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: 2bb5:10de
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 1488c81eba6320033b07ded410dd4a688968e7233608309e434678488ab533f3
+            number_of_gpus: '2'
+            pp: '1'
+            precision: fp8
+            profile: throughput
+            tp: '1'
+      modelFormat: trt-llm
+      spec:
+      - key: PROFILE
+        value: THROUGHPUT
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: GPU DEVICE
+        value: 2BB5:10DE
+      - key: NIM VERSION
+        value: 1.12.0
+      - key: DOWNLOAD SIZE
+        value: 87GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v0-1:hf-a60832c-tool-use-v2-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Mixtral 8x7b Instruct V0.1 RTX6000_BLACKWELL_SVx2 BF16
+      ngcMetadata:
+        3d73091fd6b66d810cbb9dd011fd842d2a1482a02258ff05f31cd9b00d91f3db:
+          model: mistralai/mixtral-8x7b-instruct-v0.1
+          release: 1.12.0
+          tags:
+            feat_lora: 'true'
+            feat_lora_max_rank: '32'
+            llm_engine: vllm
+            nim_workspace_hash_v1: 1143086cd34eaa9e23556534ece80597734ec4653acf4ed38fc87f993b235371
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 1.12.0
+      - key: DOWNLOAD SIZE
+        value: 87GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v0-1:hf-a60832c-tool-use-v2-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Mixtral 8x7b Instruct V0.1 RTX6000_BLACKWELL_SVx4 BF16
+      ngcMetadata:
+        dd8ce8a7f1a9025f007275f451a6e8b289f4e7b4fea07ac9664ad04b10d1e030:
+          model: mistralai/mixtral-8x7b-instruct-v0.1
+          release: 1.12.0
+          tags:
+            feat_lora: 'true'
+            feat_lora_max_rank: '32'
+            llm_engine: vllm
+            nim_workspace_hash_v1: 1143086cd34eaa9e23556534ece80597734ec4653acf4ed38fc87f993b235371
+            pp: '1'
+            precision: bf16
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 1.12.0
+      - key: DOWNLOAD SIZE
+        value: 87GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/mistralai/mixtral-8x7b-instruct-v0-1:hf-a60832c-tool-use-v2-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Mixtral 8x7b Instruct V0.1 RTX6000_BLACKWELL_SVx8 BF16
+      ngcMetadata:
+        b85a412ddf8383e654e9be84de4a2697b5096e5e0f9ca33b43bd1d61968552e8:
+          model: mistralai/mixtral-8x7b-instruct-v0.1
+          release: 1.12.0
+          tags:
+            feat_lora: 'true'
+            feat_lora_max_rank: '32'
+            llm_engine: vllm
+            nim_workspace_hash_v1: 1143086cd34eaa9e23556534ece80597734ec4653acf4ed38fc87f993b235371
+            pp: '1'
+            precision: bf16
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 1.12.0
+      - key: DOWNLOAD SIZE
+        value: 87GB
+      - key: LLM ENGINE
+        value: VLLM
   labels:
   - Mistral
   - Instruct

--- a/models/public/nemotron-3-nano.yaml
+++ b/models/public/nemotron-3-nano.yaml
@@ -2242,6 +2242,366 @@ models:
         value: 19GB
       - key: LLM ENGINE
         value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-52469ad-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx1 BF16
+      ngcMetadata:
+        352d88f8021d0ce396a61d10e929d1d4b45f75038b593595d0d92f80a398a032:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '63.0'
+            pp: '1'
+            precision: bf16
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 59GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-fp8-f25a17a-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx1 FP8
+      ngcMetadata:
+        8c91cce84b9b032ff4af489cb1a20395e223af35623010df9155390ab2284b7a:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '34.0'
+            pp: '1'
+            precision: fp8
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 31GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-nvfp4-bd1ffb1-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx1 NVFP4
+      ngcMetadata:
+        1fba9ecfcfb4cde28d4ce3fd55c40bca89a5a613e25e98f057befe6a7e99eada:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '21.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 19GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-52469ad-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx2 BF16
+      ngcMetadata:
+        004cb37f8eab12f30a94f183e0d9b0b1ab2858b17ab80de45138644c2e7007c1:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '34.0'
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 59GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-fp8-f25a17a-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx2 FP8
+      ngcMetadata:
+        49b534e3f90332a7af2d5c9932056e4482ce15fdfe19a596dfd9d662c63309ac:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '19.0'
+            pp: '1'
+            precision: fp8
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 31GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-nvfp4-bd1ffb1-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx2 NVFP4
+      ngcMetadata:
+        c7c492a20a88cb3ca9617f5de293ffabc6f382acd0e57daab70f8cf8f659231c:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '13.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 19GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-52469ad-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx4 BF16
+      ngcMetadata:
+        7c15a5935e32cad80808a37dbb3bb8de4e3eb8231eec55842866d4cfa11db426:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '19.0'
+            pp: '1'
+            precision: bf16
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 59GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-fp8-f25a17a-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx4 FP8
+      ngcMetadata:
+        9412ea9de9fdffb496984fc03b83a95f10e8d23cd019253f60283a7beeaf6a15:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '12.0'
+            pp: '1'
+            precision: fp8
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 31GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-nvfp4-bd1ffb1-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx4 NVFP4
+      ngcMetadata:
+        f49cfb0dd09f937b0515b57b5439c72694059c34af07281b41f1a83f438cbd20:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '9.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 19GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-52469ad-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx8 BF16
+      ngcMetadata:
+        2b28b859b310b857ac6cf272d42a2c984995ba0266f78725f4e26f73eb8ee5ba:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '12.0'
+            pp: '1'
+            precision: bf16
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 59GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-fp8-f25a17a-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx8 FP8
+      ngcMetadata:
+        12f8f7295a37cd1a9b6a3559b0d7449f6ca42ee7b5007de62208385ca1d75d0b:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '8.0'
+            pp: '1'
+            precision: fp8
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 31GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-nano:hf-nvfp4-bd1ffb1-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Nemotron 3 Nano RTX6000_BLACKWELL_SVx8 NVFP4
+      ngcMetadata:
+        b5654c68ac107bc904007487ffe71ede6cb9a560e281929377b623d678f613b6:
+          model: nvidia/nemotron-3-nano
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '7.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 19GB
+      - key: LLM ENGINE
+        value: VLLM
   labels:
   - Chatbots
   - Virtual Assistants

--- a/models/public/nemotron-3-super-120b-a12b.yaml
+++ b/models/public/nemotron-3-super-120b-a12b.yaml
@@ -1698,6 +1698,366 @@ models:
         value: 75GB
       - key: LLM ENGINE
         value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-bf16-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx1 BF16
+      ngcMetadata:
+        9489f6f6de7ac7c9571b123c30b47a89e80b7881882d3124ab811388d7426ddb:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '237.0'
+            pp: '1'
+            precision: bf16
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 231GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-fp8-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx1 FP8
+      ngcMetadata:
+        5a1a326f51f49bebc8b6e374b1a71e242169e5eb88ef34ab781d0109c7eb7768:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '125.0'
+            pp: '1'
+            precision: fp8
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 120GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-nvfp4-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx1 NVFP4
+      ngcMetadata:
+        3b37a659a22c9390abe7b16aeb29c301c2e9c0e12e5b0fa76171681df31930e0:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '80.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 75GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-bf16-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx2 BF16
+      ngcMetadata:
+        37fe705735f5e860db323d70e43a6e31d1274ba4cf92401c8f3ff7e8a84f093c:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '121.0'
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 231GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-fp8-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx2 FP8
+      ngcMetadata:
+        57d42cc7d33914933427e7f8d8cb1773bc11e5c96826c92095820a8776e6a4f6:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '65.0'
+            pp: '1'
+            precision: fp8
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 120GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-nvfp4-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx2 NVFP4
+      ngcMetadata:
+        7cbcde87a4f6ae47e4ed6a12d236e84672f718a418b3eeb66b1249dec74c7109:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '42.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 75GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-bf16-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx4 BF16
+      ngcMetadata:
+        2f4c50e34aec6bc548c85c8341eda99896c990dd777efb2afc658ecec6f08e30:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '63.0'
+            pp: '1'
+            precision: bf16
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 231GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-fp8-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx4 FP8
+      ngcMetadata:
+        2ed42dc23f8e95f1fc0d2b50658a309344c3892bb99eea5c992679084a3ad52f:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '35.0'
+            pp: '1'
+            precision: fp8
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 120GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-nvfp4-rtx6000_blackwell_sv-tp4
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx4 NVFP4
+      ngcMetadata:
+        d08504a72861c984173b37188d78c7150a69570afdc56ca5a585edc9226115e2:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '24.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '4'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 4
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 75GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-bf16-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx8 BF16
+      ngcMetadata:
+        4a05267a2849aa326117676f55ae1a436e3a59f275d4c4e8ea8fed2190b5dea6:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'true'
+            llm_engine: vllm
+            min_vram_per_device_gb: '35.0'
+            pp: '1'
+            precision: bf16
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 231GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-fp8-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx8 FP8
+      ngcMetadata:
+        5791516f97ec7c748456aebee86f8bb9ce618dab40055a71ab40852c09787a4c:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '21.0'
+            pp: '1'
+            precision: fp8
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: FP8
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 120GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-3-super-120b-a12b:rl-030326-nvfp4-rtx6000_blackwell_sv-tp8
+      framework: VLLM
+      displayName: Nemotron 3 Super 120B A12b RTX6000_BLACKWELL_SVx8 NVFP4
+      ngcMetadata:
+        f8aa408323c38e25046ee87549a5847d666d02de45a029a40b34719dd3fb88c9:
+          model: nvidia/nemotron-3-super-120b-a12b
+          release: 2.0.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            min_vram_per_device_gb: '15.0'
+            pp: '1'
+            precision: nvfp4
+            tp: '8'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: NVFP4
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 8
+      - key: NIM VERSION
+        value: 2.0.3
+      - key: DOWNLOAD SIZE
+        value: 75GB
+      - key: LLM ENGINE
+        value: VLLM
   labels:
   - Chatbots
   - Virtual Assistants

--- a/models/public/nemotron-nano-12b-v2-vl.yaml
+++ b/models/public/nemotron-nano-12b-v2-vl.yaml
@@ -649,6 +649,66 @@ models:
         value: 15GB
       - key: LLM ENGINE
         value: VLLM
+    - profileId: nim/nvidia/nemotron-nano-12b-v2-vl:1.5.0-bf16-hf-rtx6000_blackwell_sv
+      framework: VLLM
+      displayName: Nemotron Nano 12B V2 Vl RTX6000_BLACKWELL_SVx1 BF16
+      ngcMetadata:
+        06a217a1099a72e5d86a12a31fd39eaba9d7c00d3d311589557d2dc720b59358:
+          model: nvidia/nemotron-nano-12b-v2-vl
+          release: 1.5.0
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            nim_workspace_hash_v1: d943a0e2491f1abaae2e3c2532bc3b70535b0d8637d7b1aeed4e686f0e3e0f61
+            pp: '1'
+            precision: bf16
+            tp: '1'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 1.5.0
+      - key: DOWNLOAD SIZE
+        value: 25GB
+      - key: LLM ENGINE
+        value: VLLM
+    - profileId: nim/nvidia/nemotron-nano-12b-v2-vl:1.5.0-bf16-hf-rtx6000_blackwell_sv-tp2
+      framework: VLLM
+      displayName: Nemotron Nano 12B V2 Vl RTX6000_BLACKWELL_SVx2 BF16
+      ngcMetadata:
+        97aae95b218c9838fea29548ebaa771a922a8c9781c8450e542e323e2a76a937:
+          model: nvidia/nemotron-nano-12b-v2-vl
+          release: 1.5.0
+          tags:
+            feat_lora: 'false'
+            llm_engine: vllm
+            nim_workspace_hash_v1: d943a0e2491f1abaae2e3c2532bc3b70535b0d8637d7b1aeed4e686f0e3e0f61
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: vllm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 1.5.0
+      - key: DOWNLOAD SIZE
+        value: 25GB
+      - key: LLM ENGINE
+        value: VLLM
   labels:
   - Multimodal Vision Language Model
   - Visual Reasoning

--- a/models/public/nemotron-parse.yaml
+++ b/models/public/nemotron-parse.yaml
@@ -85,6 +85,70 @@ models:
         value: TENSORRT_LLM
       - key: TRTLLM BUILDABLE
         value: 'TRUE'
+    - profileId: nim/nvidia/nemotron-parse:hf-v5-b100
+      framework: TensorRT-LLM
+      displayName: Nemotron Parse B100x1 BF16
+      ngcMetadata:
+        a3d5f5727f27e898fc27658d0c11ff97a7de9edeff6c6065c2c838906f00dbd6:
+          model: nvidia/nemotron-parse
+          release: 1.5.0
+          tags:
+            llm_engine: tensorrt_llm
+            pp: '1'
+            precision: bf16
+            tllm_engine_config_json_str: '{"max_batch_size": 32}'
+            tp: '1'
+            trtllm_buildable: 'true'
+            gpu: B100
+            gpu_device: ''
+      modelFormat: trt-llm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: B100
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 1.5.0
+      - key: DOWNLOAD SIZE
+        value: 4GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+      - key: TRTLLM BUILDABLE
+        value: 'TRUE'
+    - profileId: nim/nvidia/nemotron-parse:hf-v5-b200
+      framework: TensorRT-LLM
+      displayName: Nemotron Parse B200x1 BF16
+      ngcMetadata:
+        a3d5f5727f27e898fc27658d0c11ff97a7de9edeff6c6065c2c838906f00dbd6:
+          model: nvidia/nemotron-parse
+          release: 1.5.0
+          tags:
+            llm_engine: tensorrt_llm
+            pp: '1'
+            precision: bf16
+            tllm_engine_config_json_str: '{"max_batch_size": 32}'
+            tp: '1'
+            trtllm_buildable: 'true'
+            gpu: B200
+            gpu_device: ''
+      modelFormat: trt-llm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: B200
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 1.5.0
+      - key: DOWNLOAD SIZE
+        value: 4GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+      - key: TRTLLM BUILDABLE
+        value: 'TRUE'
     - profileId: nim/nvidia/nemotron-parse:hf-v5-h100
       framework: TensorRT-LLM
       displayName: Nemotron Parse H100x1 BF16
@@ -179,6 +243,38 @@ models:
         value: 1
       - key: GPU DEVICE
         value: 26B9:10DE
+      - key: NIM VERSION
+        value: 1.5.0
+      - key: DOWNLOAD SIZE
+        value: 4GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+      - key: TRTLLM BUILDABLE
+        value: 'TRUE'
+    - profileId: nim/nvidia/nemotron-parse:hf-v5-rtx6000_blackwell_sv
+      framework: TensorRT-LLM
+      displayName: Nemotron Parse RTX6000_BLACKWELL_SVx1 BF16
+      ngcMetadata:
+        a3d5f5727f27e898fc27658d0c11ff97a7de9edeff6c6065c2c838906f00dbd6:
+          model: nvidia/nemotron-parse
+          release: 1.5.0
+          tags:
+            llm_engine: tensorrt_llm
+            pp: '1'
+            precision: bf16
+            tllm_engine_config_json_str: '{"max_batch_size": 32}'
+            tp: '1'
+            trtllm_buildable: 'true'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: trt-llm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
       - key: NIM VERSION
         value: 1.5.0
       - key: DOWNLOAD SIZE

--- a/models/public/starcoder-2.yaml
+++ b/models/public/starcoder-2.yaml
@@ -122,6 +122,138 @@ models:
         value: TENSORRT_LLM
       - key: TRTLLM BUILDABLE
         value: 'TRUE'
+    - profileId: nim/bigcode/starcoder2-7b:hf-bb9afde-b100
+      framework: TensorRT-LLM
+      displayName: Starcoder2 7B B100x1 BF16
+      ngcMetadata:
+        de71c59001bc42679b37ecddfd95ab7b759cfde4308071750dcf5e3558726c9b:
+          model: bigcode/starcoder2-7b
+          release: 1.15.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 43ab4fbb30e1beedda3de8df4244c9fc44fb8fbd8ba0ac23b028abf822bbf637
+            pp: '1'
+            precision: bf16
+            tp: '1'
+            trtllm_buildable: 'true'
+            gpu: B100
+            gpu_device: ''
+      modelFormat: trt-llm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: B100
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 1.15.3
+      - key: DOWNLOAD SIZE
+        value: 14GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+      - key: TRTLLM BUILDABLE
+        value: 'TRUE'
+    - profileId: nim/bigcode/starcoder2-7b:hf-bb9afde-b100-tp2
+      framework: TensorRT-LLM
+      displayName: Starcoder2 7B B100x2 BF16
+      ngcMetadata:
+        fe652f0f0ef911e255f1ff710d522d112ffda7856fe58824a9a5ef963960c909:
+          model: bigcode/starcoder2-7b
+          release: 1.15.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 43ab4fbb30e1beedda3de8df4244c9fc44fb8fbd8ba0ac23b028abf822bbf637
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            trtllm_buildable: 'true'
+            gpu: B100
+            gpu_device: ''
+      modelFormat: trt-llm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: B100
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 1.15.3
+      - key: DOWNLOAD SIZE
+        value: 14GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+      - key: TRTLLM BUILDABLE
+        value: 'TRUE'
+    - profileId: nim/bigcode/starcoder2-7b:hf-bb9afde-b200
+      framework: TensorRT-LLM
+      displayName: Starcoder2 7B B200x1 BF16
+      ngcMetadata:
+        de71c59001bc42679b37ecddfd95ab7b759cfde4308071750dcf5e3558726c9b:
+          model: bigcode/starcoder2-7b
+          release: 1.15.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 43ab4fbb30e1beedda3de8df4244c9fc44fb8fbd8ba0ac23b028abf822bbf637
+            pp: '1'
+            precision: bf16
+            tp: '1'
+            trtllm_buildable: 'true'
+            gpu: B200
+            gpu_device: ''
+      modelFormat: trt-llm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: B200
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 1.15.3
+      - key: DOWNLOAD SIZE
+        value: 14GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+      - key: TRTLLM BUILDABLE
+        value: 'TRUE'
+    - profileId: nim/bigcode/starcoder2-7b:hf-bb9afde-b200-tp2
+      framework: TensorRT-LLM
+      displayName: Starcoder2 7B B200x2 BF16
+      ngcMetadata:
+        fe652f0f0ef911e255f1ff710d522d112ffda7856fe58824a9a5ef963960c909:
+          model: bigcode/starcoder2-7b
+          release: 1.15.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 43ab4fbb30e1beedda3de8df4244c9fc44fb8fbd8ba0ac23b028abf822bbf637
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            trtllm_buildable: 'true'
+            gpu: B200
+            gpu_device: ''
+      modelFormat: trt-llm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: B200
+      - key: COUNT
+        value: 2
+      - key: NIM VERSION
+        value: 1.15.3
+      - key: DOWNLOAD SIZE
+        value: 14GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+      - key: TRTLLM BUILDABLE
+        value: 'TRUE'
     - profileId: nim/bigcode/starcoder2-7b:hf-bb9afde-h100
       framework: TensorRT-LLM
       displayName: Starcoder2 7B H100x1 BF16
@@ -540,6 +672,72 @@ models:
         value: 2
       - key: GPU DEVICE
         value: 26B9:10DE
+      - key: NIM VERSION
+        value: 1.15.3
+      - key: DOWNLOAD SIZE
+        value: 14GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+      - key: TRTLLM BUILDABLE
+        value: 'TRUE'
+    - profileId: nim/bigcode/starcoder2-7b:hf-bb9afde-rtx6000_blackwell_sv
+      framework: TensorRT-LLM
+      displayName: Starcoder2 7B RTX6000_BLACKWELL_SVx1 BF16
+      ngcMetadata:
+        de71c59001bc42679b37ecddfd95ab7b759cfde4308071750dcf5e3558726c9b:
+          model: bigcode/starcoder2-7b
+          release: 1.15.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 43ab4fbb30e1beedda3de8df4244c9fc44fb8fbd8ba0ac23b028abf822bbf637
+            pp: '1'
+            precision: bf16
+            tp: '1'
+            trtllm_buildable: 'true'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: trt-llm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 1
+      - key: NIM VERSION
+        value: 1.15.3
+      - key: DOWNLOAD SIZE
+        value: 14GB
+      - key: LLM ENGINE
+        value: TENSORRT_LLM
+      - key: TRTLLM BUILDABLE
+        value: 'TRUE'
+    - profileId: nim/bigcode/starcoder2-7b:hf-bb9afde-rtx6000_blackwell_sv-tp2
+      framework: TensorRT-LLM
+      displayName: Starcoder2 7B RTX6000_BLACKWELL_SVx2 BF16
+      ngcMetadata:
+        fe652f0f0ef911e255f1ff710d522d112ffda7856fe58824a9a5ef963960c909:
+          model: bigcode/starcoder2-7b
+          release: 1.15.3
+          tags:
+            feat_lora: 'false'
+            llm_engine: tensorrt_llm
+            nim_workspace_hash_v1: 43ab4fbb30e1beedda3de8df4244c9fc44fb8fbd8ba0ac23b028abf822bbf637
+            pp: '1'
+            precision: bf16
+            tp: '2'
+            trtllm_buildable: 'true'
+            gpu: RTX6000_BLACKWELL_SV
+            gpu_device: ''
+      modelFormat: trt-llm
+      spec:
+      - key: PRECISION
+        value: BF16
+      - key: GPU
+        value: RTX6000_BLACKWELL_SV
+      - key: COUNT
+        value: 2
       - key: NIM VERSION
         value: 1.15.3
       - key: DOWNLOAD SIZE

--- a/utils/generate-modelhub-catalog.py
+++ b/utils/generate-modelhub-catalog.py
@@ -132,6 +132,9 @@ GPU_SPECS = {
     "H100": {"memory_gb": 80, "device_id": "2330:10de"},
     "H200": {"memory_gb": 141, "device_id": "2335:10de"},
     "A100": {"memory_gb": 80, "device_id": "20b2:10de"},
+    "B100": {},
+    "B200": {},
+    "RTX6000_BLACKWELL_SV": {},
 }
 
 def _parse_gb(size_str: str):
@@ -308,6 +311,21 @@ def should_skip_gpu_count(gpu_upper, count, args):
             return True
         if count > args.a100_max_count:
             return True
+    elif gpu_upper == "B100":
+        if args.b100_min_count is not None and count < args.b100_min_count:
+            return True
+        if args.b100_max_count is not None and count > args.b100_max_count:
+            return True
+    elif gpu_upper == "B200":
+        if args.b200_min_count is not None and count < args.b200_min_count:
+            return True
+        if args.b200_max_count is not None and count > args.b200_max_count:
+            return True
+    elif gpu_upper == "RTX6000_BLACKWELL_SV":
+        if args.rtx6000_blackwell_sv_min_count is not None and count < args.rtx6000_blackwell_sv_min_count:
+            return True
+        if args.rtx6000_blackwell_sv_max_count is not None and count > args.rtx6000_blackwell_sv_max_count:
+            return True
     return False
 
 def should_exclude_riva_streaming_mode(tags):
@@ -318,7 +336,8 @@ def should_exclude_riva_streaming_mode(tags):
 def should_ignore_profile(tags, whitelisted_gpus, platform="public", include_vllm=False, include_sglang=False, a100_max_count=1,
                          a10g_min_count=None, a10g_max_count=None, l40s_min_count=None, l40s_max_count=None,
                          h100_min_count=None, h100_max_count=None, h200_min_count=None, h200_max_count=None,
-                         a100_min_count=None):
+                         a100_min_count=None, b100_min_count=None, b100_max_count=None,
+                         b200_min_count=None, b200_max_count=None, rtx6000_blackwell_sv_min_count=None, rtx6000_blackwell_sv_max_count=None):
     gpu = _get_gpu_tag(tags)
     tp = int(tags.get("tp", "1"))
     pp = int(tags.get("pp", "1"))
@@ -354,6 +373,12 @@ def should_ignore_profile(tags, whitelisted_gpus, platform="public", include_vll
         args_obj.h200_max_count = h200_max_count
         args_obj.a100_min_count = a100_min_count
         args_obj.a100_max_count = a100_max_count
+        args_obj.b100_min_count = b100_min_count
+        args_obj.b100_max_count = b100_max_count
+        args_obj.b200_min_count = b200_min_count
+        args_obj.b200_max_count = b200_max_count
+        args_obj.rtx6000_blackwell_sv_min_count = rtx6000_blackwell_sv_min_count
+        args_obj.rtx6000_blackwell_sv_max_count = rtx6000_blackwell_sv_max_count
         
         if should_skip_gpu_count(gpu.upper(), count, args_obj):
             return True
@@ -862,6 +887,12 @@ def main():
     parser.add_argument("--h200-max-count", type=int, default=None, help="Public only: Exclude H200 profiles where TP*PP > this value (default: no limit).")
     parser.add_argument("--a100-min-count", type=int, default=None, help="Public only: Exclude A100 profiles where TP*PP < this value (default: no limit).")
     parser.add_argument("--a100-max-count", type=int, default=1, help="Public only: Exclude A100 profiles where TP*PP > this value (default: 1). Use 4 to allow up to 4 GPUs.")
+    parser.add_argument("--b100-min-count", type=int, default=None, help="Public only: Exclude B100 profiles where TP*PP < this value (default: no limit).")
+    parser.add_argument("--b100-max-count", type=int, default=None, help="Public only: Exclude B100 profiles where TP*PP > this value (default: no limit).")
+    parser.add_argument("--b200-min-count", type=int, default=None, help="Public only: Exclude B200 profiles where TP*PP < this value (default: no limit).")
+    parser.add_argument("--b200-max-count", type=int, default=None, help="Public only: Exclude B200 profiles where TP*PP > this value (default: no limit).")
+    parser.add_argument("--rtx6000-blackwell-sv-min-count", type=int, default=None, help="Public only: Exclude RTX6000_BLACKWELL_SV profiles where TP*PP < this value (default: no limit).")
+    parser.add_argument("--rtx6000-blackwell-sv-max-count", type=int, default=None, help="Public only: Exclude RTX6000_BLACKWELL_SV profiles where TP*PP > this value (default: no limit).")
     parser.add_argument("--create-manifest-path", help="Base directory to write a copy of --profiles-yaml using path derived from first profileId (prefix before ':') with .yaml extension, preserving folder structure under this base directory.")
     # ONNX handling: included by default; allow explicit opt-out
     parser.add_argument("--include-onnx", dest="include_onnx", action="store_true", help="Include ONNX profiles as-is when tags.model_type: onnx (framework/modelFormat = ONNX/onnx). (default)")
@@ -886,7 +917,7 @@ def main():
     optimization_profiles = []
     profile_id_counts = {}
     covered_gpu_combinations = set()  # Track which GPU-TP*PP-PRECISION-PROFILE combinations already have profiles
-    target_gpus = ["A10G", "L40S", "H100", "H200", "A100"]  # GPUs to generate from generic profiles
+    target_gpus = ["A10G", "L40S", "H100", "H200", "A100", "B100", "B200", "RTX6000_BLACKWELL_SV"]  # GPUs to generate from generic profiles
 
     # First pass: Process regular profiles (those with specific GPUs)
     for profile in profiles:
@@ -991,7 +1022,8 @@ def main():
             if should_ignore_profile(tags, args.whitelisted_gpus, args.platform, args.include_vllm, args.include_sglang, args.a100_max_count,
                                    args.a10g_min_count, args.a10g_max_count, args.l40s_min_count, args.l40s_max_count,
                                    args.h100_min_count, args.h100_max_count, args.h200_min_count, args.h200_max_count,
-                                   args.a100_min_count):
+                                   args.a100_min_count, args.b100_min_count, args.b100_max_count,
+                                   args.b200_min_count, args.b200_max_count, args.rtx6000_blackwell_sv_min_count, args.rtx6000_blackwell_sv_max_count):
                 continue
         else:
             # Basic tag-based filters


### PR DESCRIPTION
## Summary
- Added support for new Blackwell GPU types (B100, B200, RTX6000_BLACKWELL_SV) in the generate-modelhub-catalog.py script
- Added command-line arguments for GPU count filtering on the new Blackwell GPU types
- Updated GPU_SPECS dictionary with flexible support for new GPU types (no hardcoded device IDs or memory values)
- Updated should_skip_gpu_count() function to handle B100, B200, and RTX6000_BLACKWELL_SV GPU count constraints
- Updated should_ignore_profile() function signature and implementation to support new GPU parameters
- Regenerated model catalog files for all versions (1.58.0, 1.59.0, and public) with profiles for new GPU types

## Changes Made
1. **Script Enhancement (generate-modelhub-catalog.py)**:
   - Added B100, B200, RTX6000_BLACKWELL_SV to GPU_SPECS with empty mappings (flexible)
   - Added 6 new command-line arguments: --b100-min-count, --b100-max-count, --b200-min-count, --b200-max-count, --rtx6000-blackwell-sv-min-count, --rtx6000-blackwell-sv-max-count
   - Extended should_skip_gpu_count() to validate GPU counts for all three new GPU types
   - Updated should_ignore_profile() function to accept and handle new GPU parameters
   - Updated function calls to pass new GPU count arguments

2. **Model Catalog Updates**:
   - Regenerated catalogs for cosmos-reason2-8b, gpt-oss, llama models, minimax-m25, mixtral, nemotron models, and starcoder-2
   - Catalogs updated across public, 1.58.0, and 1.59.0 versions
   - New profiles reflect g7 instance support with appropriate GPU configurations