### PR TITLE
DSE-56710: Pull in updated manifest for starcoder

### DIFF
--- a/manifests/1.14.0/nim/bigcode/starcoder2-7b.yaml
+++ b/manifests/1.14.0/nim/bigcode/starcoder2-7b.yaml
@@ -1,3 +1,5 @@
+schema_version: '2.0'
+profile_selection_criteria: auto
 model: bigcode/starcoder2-7b # fixed by cloudera; was: `starcoder2-7b`
 release: 1.15.3
 profiles:

--- a/manifests/1.16.0/nim/bigcode/starcoder2-7b.yaml
+++ b/manifests/1.16.0/nim/bigcode/starcoder2-7b.yaml
@@ -1,3 +1,5 @@
+schema_version: '2.0'
+profile_selection_criteria: auto
 model: bigcode/starcoder2-7b # fixed by cloudera; was: `starcoder2-7b`
 release: 1.15.3
 profiles:

--- a/manifests/1.17.0/nim/bigcode/starcoder2-7b.yaml
+++ b/manifests/1.17.0/nim/bigcode/starcoder2-7b.yaml
@@ -1,3 +1,5 @@
+schema_version: '2.0'
+profile_selection_criteria: auto
 model: bigcode/starcoder2-7b # fixed by cloudera; was: `starcoder2-7b`
 release: 1.15.3
 profiles:


### PR DESCRIPTION
- Starcoder download was failing due to incorrect manifest - DSE-56650: Download of starcoder model missing due to missing mainifest attributes Resolved
- CAII team has fixed the manifest
- We need to pull in that update manifest into CAIR as without that customers will report that starcoder has regressed with 05-1 and SP3
- This was found during testing