### PR TITLE
Revert "Agentic AI" category for Nemotron Super 49B and 120B

### DIFF
--- a/models/csk/1.57.0/llama-3.3-nemotron-super-49b.yaml
+++ b/models/csk/1.57.0/llama-3.3-nemotron-super-49b.yaml
@@ -2,7 +2,7 @@ models:
 - name: Llama 3.3 Nemotron Super 49B
   displayName: Llama 3.3 Nemotron Super 49B
   modelHubID: llama-3.3-nemotron-super-49b
-  category: Agentic AI
+  category: Language
   type: NGC
   description: NVIDIA-tuned instruction model delivering frontier-level accuracy across reasoning, coding, and chat. Optimized for STEM, instruction following, and agentic benchmarks.
   requireLicense: true

--- a/models/csk/1.57.0/nemotron-3-super-120b-a12b.yaml
+++ b/models/csk/1.57.0/nemotron-3-super-120b-a12b.yaml
@@ -2,7 +2,7 @@ models:
 - name: Nemotron 3 Super 120B A12B
   displayName: Nemotron 3 Super 120B A12B
   modelHubID: nemotron-3-super-120b-a12b
-  category: Agentic AI
+  category: Language
   type: NGC
   description: Hybrid MoE model combining Mamba and Transformer architectures for reasoning, coding, and long-context tasks up to ~1M tokens. Only 12B parameters active per forward pass for efficient inference.
   requireLicense: true

--- a/models/csk/1.59.0/llama-3.3-nemotron-super-49b.yaml
+++ b/models/csk/1.59.0/llama-3.3-nemotron-super-49b.yaml
@@ -2,7 +2,7 @@ models:
 - name: Llama 3.3 Nemotron Super 49B
   displayName: Llama 3.3 Nemotron Super 49B
   modelHubID: llama-3.3-nemotron-super-49b
-  category: Agentic AI
+  category: Language
   type: NGC
   description: NVIDIA-tuned instruction model delivering frontier-level accuracy across reasoning, coding, and chat. Optimized for STEM, instruction following, and agentic benchmarks.
   requireLicense: true

--- a/models/csk/1.59.0/nemotron-3-super-120b-a12b.yaml
+++ b/models/csk/1.59.0/nemotron-3-super-120b-a12b.yaml
@@ -2,7 +2,7 @@ models:
 - name: Nemotron 3 Super 120B A12B
   displayName: Nemotron 3 Super 120B A12B
   modelHubID: nemotron-3-super-120b-a12b
-  category: Agentic AI
+  category: Language
   type: NGC
   description: Hybrid MoE model combining Mamba and Transformer architectures for reasoning, coding, and long-context tasks up to ~1M tokens. Only 12B parameters active per forward pass for efficient inference.
   requireLicense: true

--- a/models/csk/llama-3.3-nemotron-super-49b.yaml
+++ b/models/csk/llama-3.3-nemotron-super-49b.yaml
@@ -2,7 +2,7 @@ models:
 - name: Llama 3.3 Nemotron Super 49B
   displayName: Llama 3.3 Nemotron Super 49B
   modelHubID: llama-3.3-nemotron-super-49b
-  category: Agentic AI
+  category: Language
   type: NGC
   description: NVIDIA-tuned instruction model delivering frontier-level accuracy across reasoning, coding, and chat. Optimized for STEM, instruction following, and agentic benchmarks.
   requireLicense: true

--- a/models/csk/nemotron-3-super-120b-a12b.yaml
+++ b/models/csk/nemotron-3-super-120b-a12b.yaml
@@ -2,7 +2,7 @@ models:
 - name: Nemotron 3 Super 120B A12B
   displayName: Nemotron 3 Super 120B A12B
   modelHubID: nemotron-3-super-120b-a12b
-  category: Agentic AI
+  category: Language
   type: NGC
   description: Hybrid MoE model combining Mamba and Transformer architectures for reasoning, coding, and long-context tasks up to ~1M tokens. Only 12B parameters active per forward pass for efficient inference.
   requireLicense: true

--- a/models/private/1.51.0-h2000/llama-3.3-nemotron-super-49b-v1.yaml
+++ b/models/private/1.51.0-h2000/llama-3.3-nemotron-super-49b-v1.yaml
@@ -2,7 +2,7 @@ models:
 - name: Llama 3.3 Nemotron Super 49B
   displayName: Llama 3.3 Nemotron Super 49B
   modelHubID: llama-3.3-nemotron-super-49b
-  category: Agentic AI
+  category: Language
   type: NGC
   description: Llama-3.3-Nemotron-Super-49B v1 and v1.5 are language models that can follow instructions, complete requests, and generate creative text formats. The Llama-3.3-Nemotron-Super-49B v1 series of Large Language Models (LLMs) are instruction-tuned versions of the Llama-Nemotron.
   requireLicense: true

--- a/models/private/1.51.0-h2100/llama-3.3-nemotron-super-49b-v1.yaml
+++ b/models/private/1.51.0-h2100/llama-3.3-nemotron-super-49b-v1.yaml
@@ -2,7 +2,7 @@ models:
 - name: Llama 3.3 Nemotron Super 49B
   displayName: Llama 3.3 Nemotron Super 49B
   modelHubID: llama-3.3-nemotron-super-49b
-  category: Agentic AI
+  category: Language
   type: NGC
   description: Llama-3.3-Nemotron-Super-49B v1 and v1.5 are language models that can follow instructions, complete requests, and generate creative text formats. The Llama-3.3-Nemotron-Super-49B v1 series of Large Language Models (LLMs) are instruction-tuned versions of the Llama-Nemotron.
   requireLicense: true

--- a/models/private/1.56.0-h3000/llama-3.3-nemotron-super-49b.yaml
+++ b/models/private/1.56.0-h3000/llama-3.3-nemotron-super-49b.yaml
@@ -2,7 +2,7 @@ models:
 - name: Llama 3.3 Nemotron Super 49B
   displayName: Llama 3.3 Nemotron Super 49B
   modelHubID: llama-3.3-nemotron-super-49b
-  category: Agentic AI
+  category: Language
   type: NGC
   description: NVIDIA-tuned instruction model delivering frontier-level accuracy across reasoning, coding, and chat. Optimized for STEM, instruction following, and agentic benchmarks.
   requireLicense: true

--- a/models/private/1.56.0-h3000/nemotron-3-super-120b-a12b.yaml
+++ b/models/private/1.56.0-h3000/nemotron-3-super-120b-a12b.yaml
@@ -2,7 +2,7 @@ models:
 - name: Nemotron 3 Super 120B A12B
   displayName: Nemotron 3 Super 120B A12B
   modelHubID: nemotron-3-super-120b-a12b
-  category: Agentic AI
+  category: Language
   type: NGC
   description: Hybrid MoE model combining Mamba and Transformer architectures for reasoning, coding, and long-context tasks up to ~1M tokens. Only 12B parameters active per forward pass for efficient inference.
   requireLicense: true

--- a/models/private/1.56.0/llama-3.3-nemotron-super-49b.yaml
+++ b/models/private/1.56.0/llama-3.3-nemotron-super-49b.yaml
@@ -2,7 +2,7 @@ models:
 - name: Llama 3.3 Nemotron Super 49B
   displayName: Llama 3.3 Nemotron Super 49B
   modelHubID: llama-3.3-nemotron-super-49b
-  category: Agentic AI
+  category: Language
   type: NGC
   description: NVIDIA-tuned instruction model delivering frontier-level accuracy across reasoning, coding, and chat. Optimized for STEM, instruction following, and agentic benchmarks.
   requireLicense: true

--- a/models/private/1.56.0/nemotron-3-super-120b-a12b.yaml
+++ b/models/private/1.56.0/nemotron-3-super-120b-a12b.yaml
@@ -2,7 +2,7 @@ models:
 - name: Nemotron 3 Super 120B A12B
   displayName: Nemotron 3 Super 120B A12B
   modelHubID: nemotron-3-super-120b-a12b
-  category: Agentic AI
+  category: Language
   type: NGC
   description: Hybrid MoE model combining Mamba and Transformer architectures for reasoning, coding, and long-context tasks up to ~1M tokens. Only 12B parameters active per forward pass for efficient inference.
   requireLicense: true

--- a/models/private/1.59.0/llama-3.3-nemotron-super-49b.yaml
+++ b/models/private/1.59.0/llama-3.3-nemotron-super-49b.yaml
@@ -2,7 +2,7 @@ models:
 - name: Llama 3.3 Nemotron Super 49B
   displayName: Llama 3.3 Nemotron Super 49B
   modelHubID: llama-3.3-nemotron-super-49b
-  category: Agentic AI
+  category: Language
   type: NGC
   description: NVIDIA-tuned instruction model delivering frontier-level accuracy across reasoning, coding, and chat. Optimized for STEM, instruction following, and agentic benchmarks.
   requireLicense: true

--- a/models/private/1.59.0/nemotron-3-super-120b-a12b.yaml
+++ b/models/private/1.59.0/nemotron-3-super-120b-a12b.yaml
@@ -2,7 +2,7 @@ models:
 - name: Nemotron 3 Super 120B A12B
   displayName: Nemotron 3 Super 120B A12B
   modelHubID: nemotron-3-super-120b-a12b
-  category: Agentic AI
+  category: Language
   type: NGC
   description: Hybrid MoE model combining Mamba and Transformer architectures for reasoning, coding, and long-context tasks up to ~1M tokens. Only 12B parameters active per forward pass for efficient inference.
   requireLicense: true

--- a/models/private/llama-3.3-nemotron-super-49b.yaml
+++ b/models/private/llama-3.3-nemotron-super-49b.yaml
@@ -2,7 +2,7 @@ models:
 - name: Llama 3.3 Nemotron Super 49B
   displayName: Llama 3.3 Nemotron Super 49B
   modelHubID: llama-3.3-nemotron-super-49b
-  category: Agentic AI
+  category: Language
   type: NGC
   description: NVIDIA-tuned instruction model delivering frontier-level accuracy across reasoning, coding, and chat. Optimized for STEM, instruction following, and agentic benchmarks.
   requireLicense: true

--- a/models/private/nemotron-3-super-120b-a12b.yaml
+++ b/models/private/nemotron-3-super-120b-a12b.yaml
@@ -2,7 +2,7 @@ models:
 - name: Nemotron 3 Super 120B A12B
   displayName: Nemotron 3 Super 120B A12B
   modelHubID: nemotron-3-super-120b-a12b
-  category: Agentic AI
+  category: Language
   type: NGC
   description: Hybrid MoE model combining Mamba and Transformer architectures for reasoning, coding, and long-context tasks up to ~1M tokens. Only 12B parameters active per forward pass for efficient inference.
   requireLicense: true

--- a/models/public/1.53.0/llama-3.3-nemotron-super-49b.yaml
+++ b/models/public/1.53.0/llama-3.3-nemotron-super-49b.yaml
@@ -2,7 +2,7 @@ models:
 - name: Llama 3.3 Nemotron Super 49B
   displayName: Llama 3.3 Nemotron Super 49B
   modelHubID: llama-3.3-nemotron-super-49b
-  category: Agentic AI
+  category: Language
   type: NGC
   description: Llama-3.3-Nemotron-Super-49B v1 and v1.5 are language models that can follow instructions, complete requests, and generate creative text formats. The Llama-3.3-Nemotron-Super-49B v1 series of Large Language Models (LLMs) are instruction-tuned versions of the Llama-Nemotron.
   requireLicense: true

--- a/models/public/1.55.0-h1000/llama-3.3-nemotron-super-49b.yaml
+++ b/models/public/1.55.0-h1000/llama-3.3-nemotron-super-49b.yaml
@@ -2,7 +2,7 @@ models:
 - name: Llama 3.3 Nemotron Super 49B
   displayName: Llama 3.3 Nemotron Super 49B
   modelHubID: llama-3.3-nemotron-super-49b
-  category: Agentic AI
+  category: Language
   type: NGC
   description: NVIDIA-tuned instruction model delivering frontier-level accuracy across reasoning, coding, and chat. Optimized for STEM, instruction following, and agentic benchmarks.
   requireLicense: true

--- a/models/public/1.55.0-h1000/nemotron-3-super-120b-a12b.yaml
+++ b/models/public/1.55.0-h1000/nemotron-3-super-120b-a12b.yaml
@@ -2,7 +2,7 @@ models:
 - name: Nemotron 3 Super 120B A12B
   displayName: Nemotron 3 Super 120B
   modelHubID: nemotron-3-super-120b-a12b
-  category: Agentic AI
+  category: Language
   type: NGC
   description: Hybrid MoE model combining Mamba and Transformer architectures for reasoning, coding, and long-context tasks up to ~1M tokens. Only 12B parameters active per forward pass for efficient inference.
   requireLicense: true

--- a/models/public/1.55.0/llama-3.3-nemotron-super-49b.yaml
+++ b/models/public/1.55.0/llama-3.3-nemotron-super-49b.yaml
@@ -2,7 +2,7 @@ models:
 - name: Llama 3.3 Nemotron Super 49B
   displayName: Llama 3.3 Nemotron Super 49B
   modelHubID: llama-3.3-nemotron-super-49b
-  category: Agentic AI
+  category: Language
   type: NGC
   description: Llama-3.3-Nemotron-Super-49B v1 and v1.5 are language models that can follow instructions, complete requests, and generate creative text formats. The Llama-3.3-Nemotron-Super-49B v1 series of Large Language Models (LLMs) are instruction-tuned versions of the Llama-Nemotron.
   requireLicense: true

--- a/models/public/1.58.0/llama-3.3-nemotron-super-49b.yaml
+++ b/models/public/1.58.0/llama-3.3-nemotron-super-49b.yaml
@@ -2,7 +2,7 @@ models:
 - name: Llama 3.3 Nemotron Super 49B
   displayName: Llama 3.3 Nemotron Super 49B
   modelHubID: llama-3.3-nemotron-super-49b
-  category: Agentic AI
+  category: Language
   type: NGC
   description: NVIDIA-tuned instruction model delivering frontier-level accuracy across reasoning, coding, and chat. Optimized for STEM, instruction following, and agentic benchmarks.
   requireLicense: true

--- a/models/public/1.58.0/nemotron-3-super-120b-a12b.yaml
+++ b/models/public/1.58.0/nemotron-3-super-120b-a12b.yaml
@@ -2,7 +2,7 @@ models:
 - name: Nemotron 3 Super 120B A12B
   displayName: Nemotron 3 Super 120B
   modelHubID: nemotron-3-super-120b-a12b
-  category: Agentic AI
+  category: Language
   type: NGC
   description: Hybrid MoE model combining Mamba and Transformer architectures for reasoning, coding, and long-context tasks up to ~1M tokens. Only 12B parameters active per forward pass for efficient inference.
   requireLicense: true

--- a/models/public/1.59.0/llama-3.3-nemotron-super-49b.yaml
+++ b/models/public/1.59.0/llama-3.3-nemotron-super-49b.yaml
@@ -2,7 +2,7 @@ models:
 - name: Llama 3.3 Nemotron Super 49B
   displayName: Llama 3.3 Nemotron Super 49B
   modelHubID: llama-3.3-nemotron-super-49b
-  category: Agentic AI
+  category: Language
   type: NGC
   description: NVIDIA-tuned instruction model delivering frontier-level accuracy across reasoning, coding, and chat. Optimized for STEM, instruction following, and agentic benchmarks.
   requireLicense: true

--- a/models/public/1.59.0/nemotron-3-super-120b-a12b.yaml
+++ b/models/public/1.59.0/nemotron-3-super-120b-a12b.yaml
@@ -2,7 +2,7 @@ models:
 - name: Nemotron 3 Super 120B A12B
   displayName: Nemotron 3 Super 120B
   modelHubID: nemotron-3-super-120b-a12b
-  category: Agentic AI
+  category: Language
   type: NGC
   description: Hybrid MoE model combining Mamba and Transformer architectures for reasoning, coding, and long-context tasks up to ~1M tokens. Only 12B parameters active per forward pass for efficient inference.
   requireLicense: true

--- a/models/public/llama-3.3-nemotron-super-49b.yaml
+++ b/models/public/llama-3.3-nemotron-super-49b.yaml
@@ -2,7 +2,7 @@ models:
 - name: Llama 3.3 Nemotron Super 49B
   displayName: Llama 3.3 Nemotron Super 49B
   modelHubID: llama-3.3-nemotron-super-49b
-  category: Agentic AI
+  category: Language
   type: NGC
   description: NVIDIA-tuned instruction model delivering frontier-level accuracy across reasoning, coding, and chat. Optimized for STEM, instruction following, and agentic benchmarks.
   requireLicense: true

--- a/models/public/nemotron-3-super-120b-a12b.yaml
+++ b/models/public/nemotron-3-super-120b-a12b.yaml
@@ -2,7 +2,7 @@ models:
 - name: Nemotron 3 Super 120B A12B
   displayName: Nemotron 3 Super 120B
   modelHubID: nemotron-3-super-120b-a12b
-  category: Agentic AI
+  category: Language
   type: NGC
   description: Hybrid MoE model combining Mamba and Transformer architectures for reasoning, coding, and long-context tasks up to ~1M tokens. Only 12B parameters active per forward pass for efficient inference.
   requireLicense: true


### PR DESCRIPTION
Updated category from Agentic AI to Language for llama-3.3-nemotron-super-49b and nemotron-3-super-120b-a12b across all public, private, and csk variants.