### PR TITLE
Fix Nemotron Parse category and display name

### DIFF
--- a/models/csk/1.59.0/nemotron-parse.yaml
+++ b/models/csk/1.59.0/nemotron-parse.yaml
@@ -1,8 +1,8 @@
 models:
 - name: NEMOTRON-PARSE
-  displayName: NEMOTRON-PARSE
+  displayName: Nemotron Parse
   modelHubID: nemotron-parse
-  category: Language
+  category: Retrieval
   type: NGC
   description: Nemotron-Parse is an NVIDIA model focused on structured document understanding and parsing. It converts unstructured inputs (like PDFs, forms, or images of documents) into structured outputs such as JSON, extracting elements like text, tables, key-value pairs, and layout with high accuracy—useful for data pipelines, RAG, and enterprise document processing.
   requireLicense: true

--- a/models/csk/nemotron-parse.yaml
+++ b/models/csk/nemotron-parse.yaml
@@ -1,8 +1,8 @@
 models:
 - name: NEMOTRON-PARSE
-  displayName: NEMOTRON-PARSE
+  displayName: Nemotron Parse
   modelHubID: nemotron-parse
-  category: Language
+  category: Retrieval
   type: NGC
   description: Nemotron-Parse is an NVIDIA model focused on structured document understanding and parsing. It converts unstructured inputs (like PDFs, forms, or images of documents) into structured outputs such as JSON, extracting elements like text, tables, key-value pairs, and layout with high accuracy—useful for data pipelines, RAG, and enterprise document processing.
   requireLicense: true

--- a/models/private/1.56.0-h3000/nemotron-parse.yaml
+++ b/models/private/1.56.0-h3000/nemotron-parse.yaml
@@ -1,8 +1,8 @@
 models:
 - name: NEMOTRON-PARSE
-  displayName: NEMOTRON-PARSE
+  displayName: Nemotron Parse
   modelHubID: nemotron-parse
-  category: Language
+  category: Retrieval
   type: NGC
   description: Nemotron-Parse is an NVIDIA model focused on structured document understanding and parsing. It converts unstructured inputs (like PDFs, forms, or images of documents) into structured outputs such as JSON, extracting elements like text, tables, key-value pairs, and layout with high accuracy—useful for data pipelines, RAG, and enterprise document processing.
   requireLicense: true

--- a/models/private/1.56.0/nemotron-parse.yaml
+++ b/models/private/1.56.0/nemotron-parse.yaml
@@ -1,8 +1,8 @@
 models:
 - name: NEMOTRON-PARSE
-  displayName: NEMOTRON-PARSE
+  displayName: Nemotron Parse
   modelHubID: nemotron-parse
-  category: Language
+  category: Retrieval
   type: NGC
   description: Nemotron-Parse is an NVIDIA model focused on structured document understanding and parsing. It converts unstructured inputs (like PDFs, forms, or images of documents) into structured outputs such as JSON, extracting elements like text, tables, key-value pairs, and layout with high accuracy—useful for data pipelines, RAG, and enterprise document processing.
   requireLicense: true

--- a/models/private/1.59.0/nemotron-parse.yaml
+++ b/models/private/1.59.0/nemotron-parse.yaml
@@ -1,8 +1,8 @@
 models:
 - name: NEMOTRON-PARSE
-  displayName: NEMOTRON-PARSE
+  displayName: Nemotron Parse
   modelHubID: nemotron-parse
-  category: Language
+  category: Retrieval
   type: NGC
   description: Nemotron-Parse is an NVIDIA model focused on structured document understanding and parsing. It converts unstructured inputs (like PDFs, forms, or images of documents) into structured outputs such as JSON, extracting elements like text, tables, key-value pairs, and layout with high accuracy—useful for data pipelines, RAG, and enterprise document processing.
   requireLicense: true

--- a/models/private/nemotron-parse.yaml
+++ b/models/private/nemotron-parse.yaml
@@ -1,8 +1,8 @@
 models:
 - name: NEMOTRON-PARSE
-  displayName: NEMOTRON-PARSE
+  displayName: Nemotron Parse
   modelHubID: nemotron-parse
-  category: Language
+  category: Retrieval
   type: NGC
   description: Nemotron-Parse is an NVIDIA model focused on structured document understanding and parsing. It converts unstructured inputs (like PDFs, forms, or images of documents) into structured outputs such as JSON, extracting elements like text, tables, key-value pairs, and layout with high accuracy—useful for data pipelines, RAG, and enterprise document processing.
   requireLicense: true

--- a/models/public/1.58.0/nemotron-parse.yaml
+++ b/models/public/1.58.0/nemotron-parse.yaml
@@ -1,8 +1,8 @@
 models:
 - name: NEMOTRON-PARSE
-  displayName: NEMOTRON-PARSE
+  displayName: Nemotron Parse
   modelHubID: nemotron-parse
-  category: Language
+  category: Retrieval
   type: NGC
   description: Nemotron-Parse is an NVIDIA model focused on structured document understanding and parsing. It converts unstructured inputs (like PDFs, forms, or images of documents) into structured outputs such as JSON, extracting elements like text, tables, key-value pairs, and layout with high accuracy—useful for data pipelines, RAG, and enterprise document processing.
   requireLicense: true

--- a/models/public/1.59.0/nemotron-parse.yaml
+++ b/models/public/1.59.0/nemotron-parse.yaml
@@ -1,8 +1,8 @@
 models:
 - name: NEMOTRON-PARSE
-  displayName: NEMOTRON-PARSE
+  displayName: Nemotron Parse
   modelHubID: nemotron-parse
-  category: Language
+  category: Retrieval
   type: NGC
   description: Nemotron-Parse is an NVIDIA model focused on structured document understanding and parsing. It converts unstructured inputs (like PDFs, forms, or images of documents) into structured outputs such as JSON, extracting elements like text, tables, key-value pairs, and layout with high accuracy—useful for data pipelines, RAG, and enterprise document processing.
   requireLicense: true

--- a/models/public/nemotron-parse.yaml
+++ b/models/public/nemotron-parse.yaml
@@ -1,8 +1,8 @@
 models:
 - name: NEMOTRON-PARSE
-  displayName: NEMOTRON-PARSE
+  displayName: Nemotron Parse
   modelHubID: nemotron-parse
-  category: Language
+  category: Retrieval
   type: NGC
   description: Nemotron-Parse is an NVIDIA model focused on structured document understanding and parsing. It converts unstructured inputs (like PDFs, forms, or images of documents) into structured outputs such as JSON, extracting elements like text, tables, key-value pairs, and layout with high accuracy—useful for data pipelines, RAG, and enterprise document processing.
   requireLicense: true


### PR DESCRIPTION
- Category: Language → Retrieval (it's a document parsing model for RAG/data pipelines)
- displayName: NEMOTRON-PARSE → Nemotron Parse (title case convention)