### PR TITLE
DSE-57744: BE: Add certifications attribute to relevant models in Mod…

### DIFF
--- a/models/csk/1.59.0/llama-3.3-nemotron-super-49b.yaml
+++ b/models/csk/1.59.0/llama-3.3-nemotron-super-49b.yaml
@@ -3,6 +3,8 @@ models:
   displayName: Llama 3.3 Nemotron Super 49B
   modelHubID: llama-3.3-nemotron-super-49b
   category: Language
+  certifications:
+  - Agent Studio Certified
   type: NGC
   description: NVIDIA-tuned instruction model delivering frontier-level accuracy across reasoning, coding, and chat. Optimized for STEM, instruction following, and agentic benchmarks.
   requireLicense: true

--- a/models/csk/1.59.0/nemotron-3-super-120b-a12b.yaml
+++ b/models/csk/1.59.0/nemotron-3-super-120b-a12b.yaml
@@ -3,6 +3,8 @@ models:
   displayName: Nemotron 3 Super 120B A12B
   modelHubID: nemotron-3-super-120b-a12b
   category: Language
+  certifications:
+  - Agent Studio Certified
   type: NGC
   description: Hybrid MoE model combining Mamba and Transformer architectures for reasoning, coding, and long-context tasks up to ~1M tokens. Only 12B parameters active per forward pass for efficient inference.
   requireLicense: true

--- a/models/csk/llama-3.3-nemotron-super-49b.yaml
+++ b/models/csk/llama-3.3-nemotron-super-49b.yaml
@@ -3,6 +3,8 @@ models:
   displayName: Llama 3.3 Nemotron Super 49B
   modelHubID: llama-3.3-nemotron-super-49b
   category: Language
+  certifications:
+  - Agent Studio Certified
   type: NGC
   description: NVIDIA-tuned instruction model delivering frontier-level accuracy across reasoning, coding, and chat. Optimized for STEM, instruction following, and agentic benchmarks.
   requireLicense: true

--- a/models/csk/nemotron-3-super-120b-a12b.yaml
+++ b/models/csk/nemotron-3-super-120b-a12b.yaml
@@ -3,6 +3,8 @@ models:
   displayName: Nemotron 3 Super 120B A12B
   modelHubID: nemotron-3-super-120b-a12b
   category: Language
+  certifications:
+  - Agent Studio Certified
   type: NGC
   description: Hybrid MoE model combining Mamba and Transformer architectures for reasoning, coding, and long-context tasks up to ~1M tokens. Only 12B parameters active per forward pass for efficient inference.
   requireLicense: true

--- a/models/private/1.59.0/llama-3.3-nemotron-super-49b.yaml
+++ b/models/private/1.59.0/llama-3.3-nemotron-super-49b.yaml
@@ -3,6 +3,8 @@ models:
   displayName: Llama 3.3 Nemotron Super 49B
   modelHubID: llama-3.3-nemotron-super-49b
   category: Language
+  certifications:
+  - Agent Studio Certified
   type: NGC
   description: NVIDIA-tuned instruction model delivering frontier-level accuracy across reasoning, coding, and chat. Optimized for STEM, instruction following, and agentic benchmarks.
   requireLicense: true

--- a/models/private/1.59.0/nemotron-3-super-120b-a12b.yaml
+++ b/models/private/1.59.0/nemotron-3-super-120b-a12b.yaml
@@ -3,6 +3,8 @@ models:
   displayName: Nemotron 3 Super 120B A12B
   modelHubID: nemotron-3-super-120b-a12b
   category: Language
+  certifications:
+  - Agent Studio Certified
   type: NGC
   description: Hybrid MoE model combining Mamba and Transformer architectures for reasoning, coding, and long-context tasks up to ~1M tokens. Only 12B parameters active per forward pass for efficient inference.
   requireLicense: true

--- a/models/private/llama-3.3-nemotron-super-49b.yaml
+++ b/models/private/llama-3.3-nemotron-super-49b.yaml
@@ -3,6 +3,8 @@ models:
   displayName: Llama 3.3 Nemotron Super 49B
   modelHubID: llama-3.3-nemotron-super-49b
   category: Language
+  certifications:
+  - Agent Studio Certified
   type: NGC
   description: NVIDIA-tuned instruction model delivering frontier-level accuracy across reasoning, coding, and chat. Optimized for STEM, instruction following, and agentic benchmarks.
   requireLicense: true

--- a/models/private/nemotron-3-super-120b-a12b.yaml
+++ b/models/private/nemotron-3-super-120b-a12b.yaml
@@ -3,6 +3,8 @@ models:
   displayName: Nemotron 3 Super 120B A12B
   modelHubID: nemotron-3-super-120b-a12b
   category: Language
+  certifications:
+  - Agent Studio Certified
   type: NGC
   description: Hybrid MoE model combining Mamba and Transformer architectures for reasoning, coding, and long-context tasks up to ~1M tokens. Only 12B parameters active per forward pass for efficient inference.
   requireLicense: true

--- a/models/public/1.59.0/llama-3.3-nemotron-super-49b.yaml
+++ b/models/public/1.59.0/llama-3.3-nemotron-super-49b.yaml
@@ -3,6 +3,8 @@ models:
   displayName: Llama 3.3 Nemotron Super 49B
   modelHubID: llama-3.3-nemotron-super-49b
   category: Language
+  certifications:
+  - Agent Studio Certified
   type: NGC
   description: NVIDIA-tuned instruction model delivering frontier-level accuracy across reasoning, coding, and chat. Optimized for STEM, instruction following, and agentic benchmarks.
   requireLicense: true

--- a/models/public/1.59.0/nemotron-3-super-120b-a12b.yaml
+++ b/models/public/1.59.0/nemotron-3-super-120b-a12b.yaml
@@ -3,6 +3,8 @@ models:
   displayName: Nemotron 3 Super 120B
   modelHubID: nemotron-3-super-120b-a12b
   category: Language
+  certifications:
+  - Agent Studio Certified
   type: NGC
   description: Hybrid MoE model combining Mamba and Transformer architectures for reasoning, coding, and long-context tasks up to ~1M tokens. Only 12B parameters active per forward pass for efficient inference.
   requireLicense: true

--- a/models/public/llama-3.3-nemotron-super-49b.yaml
+++ b/models/public/llama-3.3-nemotron-super-49b.yaml
@@ -3,6 +3,8 @@ models:
   displayName: Llama 3.3 Nemotron Super 49B
   modelHubID: llama-3.3-nemotron-super-49b
   category: Language
+  certifications:
+  - Agent Studio Certified
   type: NGC
   description: NVIDIA-tuned instruction model delivering frontier-level accuracy across reasoning, coding, and chat. Optimized for STEM, instruction following, and agentic benchmarks.
   requireLicense: true

--- a/models/public/nemotron-3-super-120b-a12b.yaml
+++ b/models/public/nemotron-3-super-120b-a12b.yaml
@@ -3,6 +3,8 @@ models:
   displayName: Nemotron 3 Super 120B
   modelHubID: nemotron-3-super-120b-a12b
   category: Language
+  certifications:
+  - Agent Studio Certified
   type: NGC
   description: Hybrid MoE model combining Mamba and Transformer architectures for reasoning, coding, and long-context tasks up to ~1M tokens. Only 12B parameters active per forward pass for efficient inference.
   requireLicense: true


### PR DESCRIPTION
…elHub

- Adding the certifications attribute to nemotron-super-49b and nemotron-super-120b in master
- This change is backward compatible