### PR TITLE
Ensuring top-level merge-order is in sync

### DIFF
--- a/models-order/merge-order.yaml
+++ b/models-order/merge-order.yaml
@@ -1,7 +1,6 @@
 merge_order:
   - nemotron-3-super-120b-a12b.yaml
   - nemotron-3-nano.yaml
-  - nemotron-nano-12b-v2-vl.yaml
   - nemotron-parse.yaml
   - cosmos-reason2-8b.yaml
   - minimax-m25.yaml
@@ -18,11 +17,9 @@ merge_order:
   - nemoretriever-page-elements-v3.yaml
   - nemoretriever-graphic-elements-v1.yaml
   - nemoretriever-table-structure-v1.yaml
-  - paddleocr.yaml
   - llama-3.2-nv-embedqa-v2.yaml
   - llama-3.2-nv-rerankqa-v2.yaml
   - riva-asr-whisper-large-v3.yaml
   - boltz2.yaml
   - gpt-oss.yaml
-  - gemma-2.yaml
   - llama-3-sqlcoder-8b.yaml


### PR DESCRIPTION
Ensuring top-level merge-order is in sync
Noticed the discrepancy while validating ConfigureModelHub flows